### PR TITLE
fix: correct QUORUM constant documentation

### DIFF
--- a/src/governance.md
+++ b/src/governance.md
@@ -248,7 +248,8 @@ event ProposalFeeCollected(uint256 indexed proposalId, uint256 amount);
 |----------|-------|-------------|
 | `PROPOSAL_FEE` | 1,000 JUSD | Cost to create proposal |
 | `MIN_APPLICATION_PERIOD` | 14 days | Minimum veto period |
-| `QUORUM` | 2% | Voting power needed for veto |
+
+**Note:** The 2% veto threshold is not a constant in JuiceSwapGovernor. It is enforced by `JUICE.checkQualified()` in the JUICE (Equity) contract, which JuiceSwap inherits from JuiceDollar.
 
 ## Best Practices
 

--- a/src/smart-contracts.md
+++ b/src/smart-contracts.md
@@ -94,7 +94,7 @@ Governance contract using JUICE token voting with veto mechanism.
 | **Address** | [`0x205903c54C56bCED8C97f2DC250BA53d715174e9`](https://explorer.testnet.citrea.xyz/address/0x205903c54C56bCED8C97f2DC250BA53d715174e9) |
 | **Proposal Fee** | 1,000 JUSD |
 | **Min Application Period** | 14 days |
-| **Veto Quorum** | 2% |
+| **Veto Quorum** | 2% (via JUICE.checkQualified) |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes incorrect documentation claiming `QUORUM` is a constant in JuiceSwapGovernor.

## Problem

The documentation stated that `QUORUM` (2%) is a constant in the Governor contract. However, JuiceSwapGovernor only has two constants:

```solidity
uint256 public constant PROPOSAL_FEE = 1000 ether;
uint256 public constant MIN_APPLICATION_PERIOD = 14 days;
```

The 2% veto threshold is enforced by `JUICE.checkQualified()` in the JUICE (Equity) contract.

## Changes

- `governance.md`: Remove `QUORUM` from constants table, add explanatory note
- `smart-contracts.md`: Clarify that veto quorum is via `JUICE.checkQualified()`