### PR TITLE
Fix: Replace juiceswap.xyz with juiceswap.com

### DIFF
--- a/media/README.md
+++ b/media/README.md
@@ -8,10 +8,10 @@ This directory contains media assets for the JuiceSwap documentation site.
 
 The following icons are available for use:
 
-- **CBTC Icon (PNG)**: `https://docs.juiceswap.xyz/media/icons/cbtc.png`
-- **CBTC Icon (SVG)**: `https://docs.juiceswap.xyz/media/icons/cbtc.svg`
-- **CUSD Icon (PNG)**: `https://docs.juiceswap.xyz/media/icons/cusd.png`
-- **NUSD Icon (PNG)**: `https://docs.juiceswap.xyz/media/icons/nusd.png`
+- **CBTC Icon (PNG)**: `https://docs.juiceswap.com/media/icons/cbtc.png`
+- **CBTC Icon (SVG)**: `https://docs.juiceswap.com/media/icons/cbtc.svg`
+- **CUSD Icon (PNG)**: `https://docs.juiceswap.com/media/icons/cusd.png`
+- **NUSD Icon (PNG)**: `https://docs.juiceswap.com/media/icons/nusd.png`
 
 ## How to Use
 
@@ -20,19 +20,19 @@ The following icons are available for use:
 To embed images in markdown files, use the following syntax:
 
 ```markdown
-![CBTC Icon](https://docs.juiceswap.xyz/media/icons/cbtc.png)
+![CBTC Icon](https://docs.juiceswap.com/media/icons/cbtc.png)
 ```
 
 ### In HTML
 
 ```html
-<img src="https://docs.juiceswap.xyz/media/icons/cbtc.png" alt="CBTC Icon" />
+<img src="https://docs.juiceswap.com/media/icons/cbtc.png" alt="CBTC Icon" />
 ```
 
 ### Direct Link
 
 Simply use the full URL to link directly to any asset:
-- `https://docs.juiceswap.xyz/media/icons/cbtc.png`
+- `https://docs.juiceswap.com/media/icons/cbtc.png`
 
 ## Directory Structure
 
@@ -51,4 +51,4 @@ media/
 To add new media assets:
 1. Place the files in the appropriate subdirectory (e.g., `icons/` for icons)
 2. Commit and push to the repository
-3. The files will be automatically deployed and available at `https://docs.juiceswap.xyz/media/[path-to-file]`
+3. The files will be automatically deployed and available at `https://docs.juiceswap.com/media/[path-to-file]`

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -63,30 +63,30 @@ Platform-specific social media assets
 
 ### Direct Links
 ```
-https://docs.juiceswap.xyz/media_kit/01_Logo/01_Logo/PNG/Juice_Swap_full_logo.png
-https://docs.juiceswap.xyz/media_kit/02_App_Icons/Juice_Swap_512x512_App_Icon.png
-https://docs.juiceswap.xyz/media_kit/03_Website/Favicon/ICO/favicon.ico
+https://docs.juiceswap.com/media_kit/01_Logo/01_Logo/PNG/Juice_Swap_full_logo.png
+https://docs.juiceswap.com/media_kit/02_App_Icons/Juice_Swap_512x512_App_Icon.png
+https://docs.juiceswap.com/media_kit/03_Website/Favicon/ICO/favicon.ico
 ```
 
 ### In Markdown
 ```markdown
-![JuiceSwap Logo](https://docs.juiceswap.xyz/media_kit/01_Logo/01_Logo/PNG/Juice_Swap_full_logo.png)
+![JuiceSwap Logo](https://docs.juiceswap.com/media_kit/01_Logo/01_Logo/PNG/Juice_Swap_full_logo.png)
 ```
 
 ### In HTML
 ```html
-<img src="https://docs.juiceswap.xyz/media_kit/02_App_Icons/Juice_Swap_256x256_App_Icon.png" alt="JuiceSwap" />
+<img src="https://docs.juiceswap.com/media_kit/02_App_Icons/Juice_Swap_256x256_App_Icon.png" alt="JuiceSwap" />
 ```
 
 ### As Favicon
 ```html
-<link rel="icon" href="https://docs.juiceswap.xyz/media_kit/03_Website/Favicon/ICO/favicon.ico" />
-<link rel="icon" type="image/png" sizes="32x32" href="https://docs.juiceswap.xyz/media_kit/03_Website/Favicon/Juice_Swap_FavIcon_32px.png" />
+<link rel="icon" href="https://docs.juiceswap.com/media_kit/03_Website/Favicon/ICO/favicon.ico" />
+<link rel="icon" type="image/png" sizes="32x32" href="https://docs.juiceswap.com/media_kit/03_Website/Favicon/Juice_Swap_FavIcon_32px.png" />
 ```
 
 ### Open Graph Meta Tags
 ```html
-<meta property="og:image" content="https://docs.juiceswap.xyz/media_kit/03_Website/Og_image/Juice_Swap_og_image.png" />
+<meta property="og:image" content="https://docs.juiceswap.com/media_kit/03_Website/Og_image/Juice_Swap_og_image.png" />
 ```
 
 ## 🎨 Brand Guidelines

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "authors": {
     "name": "JuiceSwap",
-    "email": "info@juiceswap.xyz"
+    "email": "info@juiceswap.com"
   },
   "repository": "https://github.com/JuiceSwapxyz/documentation/",
   "scripts": {

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -10,15 +10,15 @@ module.exports = {
     ["meta", { name: "theme-color", content: "#FF9933" }],
     ["meta", { name: "apple-mobile-web-app-capable", content: "yes" }],
     ["meta", { name: "apple-mobile-web-app-status-bar-style", content: "black" }],
-    ["meta", { property: "og:image", content: "https://docs.juiceswap.xyz/assets/og_image.png" }],
+    ["meta", { property: "og:image", content: "https://docs.juiceswap.com/assets/og_image.png" }],
     ["meta", { property: "og:image:width", content: "1200" }],
     ["meta", { property: "og:image:height", content: "630" }],
     ["meta", { property: "og:title", content: "JuiceSwap Documentation" }],
     ["meta", { property: "og:description", content: "Official documentation for JuiceSwap - Decentralized Exchange Platform" }],
     ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:url", content: "https://docs.juiceswap.xyz/" }],
+    ["meta", { property: "og:url", content: "https://docs.juiceswap.com/" }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
-    ["meta", { name: "twitter:image", content: "https://docs.juiceswap.xyz/assets/og_image.png" }],
+    ["meta", { name: "twitter:image", content: "https://docs.juiceswap.com/assets/og_image.png" }],
     ["meta", { name: "twitter:title", content: "JuiceSwap Documentation" }],
     ["meta", { name: "twitter:description", content: "Official documentation for JuiceSwap - Decentralized Exchange Platform" }],
   ],
@@ -35,7 +35,7 @@ module.exports = {
     nav: [
       {
         text: "JuiceSwap.xyz",
-        link: "https://juiceswap.xyz/",
+        link: "https://juiceswap.com/",
       },
     ],
 

--- a/src/imprint.md
+++ b/src/imprint.md
@@ -43,7 +43,7 @@ The protocol consists of immutable smart contracts deployed on Citrea Testnet:
 JuiceSwap is built and maintained by its community:
 
 - **GitHub**: [github.com/JuiceSwapxyz](https://github.com/JuiceSwapxyz)
-- **Website**: [juiceswap.xyz](https://juiceswap.xyz)
+- **Website**: [juiceswap.com](https://juiceswap.com)
 
 ## Legal Notice
 


### PR DESCRIPTION
## Summary
- Replace all `juiceswap.xyz` URLs with `juiceswap.com` across documentation
- Affects meta tags, links, and asset URLs in 5 files

## Changed Files
- `media_kit/README.md` - 9 URL changes
- `media/README.md` - 7 URL changes
- `src/.vuepress/config.js` - 5 URL changes (og:image, og:url, twitter:image, nav link)
- `src/imprint.md` - 1 URL change
- `package.json` - 1 email domain change

## Test plan
- [x] Build passes locally (`yarn build`)
- [ ] Verify links work after deployment

Closes JuiceSwapxyz/bapp#391