### PR TITLE
Release: Update contract addresses to latest testnet deployment

### DIFF
--- a/media/README.md
+++ b/media/README.md
@@ -8,10 +8,10 @@ This directory contains media assets for the JuiceSwap documentation site.
 
 The following icons are available for use:
 
-- **CBTC Icon (PNG)**: `https://docs.juiceswap.xyz/media/icons/cbtc.png`
-- **CBTC Icon (SVG)**: `https://docs.juiceswap.xyz/media/icons/cbtc.svg`
-- **CUSD Icon (PNG)**: `https://docs.juiceswap.xyz/media/icons/cusd.png`
-- **NUSD Icon (PNG)**: `https://docs.juiceswap.xyz/media/icons/nusd.png`
+- **CBTC Icon (PNG)**: `https://docs.juiceswap.com/media/icons/cbtc.png`
+- **CBTC Icon (SVG)**: `https://docs.juiceswap.com/media/icons/cbtc.svg`
+- **CUSD Icon (PNG)**: `https://docs.juiceswap.com/media/icons/cusd.png`
+- **NUSD Icon (PNG)**: `https://docs.juiceswap.com/media/icons/nusd.png`
 
 ## How to Use
 
@@ -20,19 +20,19 @@ The following icons are available for use:
 To embed images in markdown files, use the following syntax:
 
 ```markdown
-![CBTC Icon](https://docs.juiceswap.xyz/media/icons/cbtc.png)
+![CBTC Icon](https://docs.juiceswap.com/media/icons/cbtc.png)
 ```
 
 ### In HTML
 
 ```html
-<img src="https://docs.juiceswap.xyz/media/icons/cbtc.png" alt="CBTC Icon" />
+<img src="https://docs.juiceswap.com/media/icons/cbtc.png" alt="CBTC Icon" />
 ```
 
 ### Direct Link
 
 Simply use the full URL to link directly to any asset:
-- `https://docs.juiceswap.xyz/media/icons/cbtc.png`
+- `https://docs.juiceswap.com/media/icons/cbtc.png`
 
 ## Directory Structure
 
@@ -51,4 +51,4 @@ media/
 To add new media assets:
 1. Place the files in the appropriate subdirectory (e.g., `icons/` for icons)
 2. Commit and push to the repository
-3. The files will be automatically deployed and available at `https://docs.juiceswap.xyz/media/[path-to-file]`
+3. The files will be automatically deployed and available at `https://docs.juiceswap.com/media/[path-to-file]`

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -63,30 +63,30 @@ Platform-specific social media assets
 
 ### Direct Links
 ```
-https://docs.juiceswap.xyz/media_kit/01_Logo/01_Logo/PNG/Juice_Swap_full_logo.png
-https://docs.juiceswap.xyz/media_kit/02_App_Icons/Juice_Swap_512x512_App_Icon.png
-https://docs.juiceswap.xyz/media_kit/03_Website/Favicon/ICO/favicon.ico
+https://docs.juiceswap.com/media_kit/01_Logo/01_Logo/PNG/Juice_Swap_full_logo.png
+https://docs.juiceswap.com/media_kit/02_App_Icons/Juice_Swap_512x512_App_Icon.png
+https://docs.juiceswap.com/media_kit/03_Website/Favicon/ICO/favicon.ico
 ```
 
 ### In Markdown
 ```markdown
-![JuiceSwap Logo](https://docs.juiceswap.xyz/media_kit/01_Logo/01_Logo/PNG/Juice_Swap_full_logo.png)
+![JuiceSwap Logo](https://docs.juiceswap.com/media_kit/01_Logo/01_Logo/PNG/Juice_Swap_full_logo.png)
 ```
 
 ### In HTML
 ```html
-<img src="https://docs.juiceswap.xyz/media_kit/02_App_Icons/Juice_Swap_256x256_App_Icon.png" alt="JuiceSwap" />
+<img src="https://docs.juiceswap.com/media_kit/02_App_Icons/Juice_Swap_256x256_App_Icon.png" alt="JuiceSwap" />
 ```
 
 ### As Favicon
 ```html
-<link rel="icon" href="https://docs.juiceswap.xyz/media_kit/03_Website/Favicon/ICO/favicon.ico" />
-<link rel="icon" type="image/png" sizes="32x32" href="https://docs.juiceswap.xyz/media_kit/03_Website/Favicon/Juice_Swap_FavIcon_32px.png" />
+<link rel="icon" href="https://docs.juiceswap.com/media_kit/03_Website/Favicon/ICO/favicon.ico" />
+<link rel="icon" type="image/png" sizes="32x32" href="https://docs.juiceswap.com/media_kit/03_Website/Favicon/Juice_Swap_FavIcon_32px.png" />
 ```
 
 ### Open Graph Meta Tags
 ```html
-<meta property="og:image" content="https://docs.juiceswap.xyz/media_kit/03_Website/Og_image/Juice_Swap_og_image.png" />
+<meta property="og:image" content="https://docs.juiceswap.com/media_kit/03_Website/Og_image/Juice_Swap_og_image.png" />
 ```
 
 ## 🎨 Brand Guidelines

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "authors": {
     "name": "JuiceSwap",
-    "email": "info@juiceswap.xyz"
+    "email": "info@juiceswap.com"
   },
   "repository": "https://github.com/JuiceSwapxyz/documentation/",
   "scripts": {

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -10,15 +10,15 @@ module.exports = {
     ["meta", { name: "theme-color", content: "#FF9933" }],
     ["meta", { name: "apple-mobile-web-app-capable", content: "yes" }],
     ["meta", { name: "apple-mobile-web-app-status-bar-style", content: "black" }],
-    ["meta", { property: "og:image", content: "https://docs.juiceswap.xyz/assets/og_image.png" }],
+    ["meta", { property: "og:image", content: "https://docs.juiceswap.com/assets/og_image.png" }],
     ["meta", { property: "og:image:width", content: "1200" }],
     ["meta", { property: "og:image:height", content: "630" }],
     ["meta", { property: "og:title", content: "JuiceSwap Documentation" }],
     ["meta", { property: "og:description", content: "Official documentation for JuiceSwap - Decentralized Exchange Platform" }],
     ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:url", content: "https://docs.juiceswap.xyz/" }],
+    ["meta", { property: "og:url", content: "https://docs.juiceswap.com/" }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
-    ["meta", { name: "twitter:image", content: "https://docs.juiceswap.xyz/assets/og_image.png" }],
+    ["meta", { name: "twitter:image", content: "https://docs.juiceswap.com/assets/og_image.png" }],
     ["meta", { name: "twitter:title", content: "JuiceSwap Documentation" }],
     ["meta", { name: "twitter:description", content: "Official documentation for JuiceSwap - Decentralized Exchange Platform" }],
   ],
@@ -35,7 +35,7 @@ module.exports = {
     nav: [
       {
         text: "JuiceSwap.xyz",
-        link: "https://juiceswap.xyz/",
+        link: "https://juiceswap.com/",
       },
     ],
 

--- a/src/governance.md
+++ b/src/governance.md
@@ -286,7 +286,7 @@ This means:
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGovernor | [`0x205903c54C56bCED8C97f2DC250BA53d715174e9`](https://explorer.testnet.citrea.xyz/address/0x205903c54C56bCED8C97f2DC250BA53d715174e9) |
-| JuiceSwapFeeCollector | [`0xc3d817C394d55aB57f5bF0Fc5C6878ccE033E32a`](https://explorer.testnet.citrea.xyz/address/0xc3d817C394d55aB57f5bF0Fc5C6878ccE033E32a) |
-| JUICE (Equity) | [`0x7b2A560bf72B0Dd2EAbE3271F829C2597c8420d5`](https://explorer.testnet.citrea.xyz/address/0x7b2A560bf72B0Dd2EAbE3271F829C2597c8420d5) |
-| UniswapV3Factory | [`0x9136D17Ec096AAd031D442a796cd5984128cF0b2`](https://explorer.testnet.citrea.xyz/address/0x9136D17Ec096AAd031D442a796cd5984128cF0b2) |
+| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
+| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
+| JUICE (Equity) | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
+| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |

--- a/src/imprint.md
+++ b/src/imprint.md
@@ -34,9 +34,9 @@ The protocol consists of immutable smart contracts deployed on Citrea Testnet:
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153`](https://explorer.testnet.citrea.xyz/address/0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153) |
-| JuiceSwapGovernor | [`0x205903c54C56bCED8C97f2DC250BA53d715174e9`](https://explorer.testnet.citrea.xyz/address/0x205903c54C56bCED8C97f2DC250BA53d715174e9) |
-| JuiceSwapFeeCollector | [`0xc3d817C394d55aB57f5bF0Fc5C6878ccE033E32a`](https://explorer.testnet.citrea.xyz/address/0xc3d817C394d55aB57f5bF0Fc5C6878ccE033E32a) |
+| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
+| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
+| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
 
 ## Community
 

--- a/src/imprint.md
+++ b/src/imprint.md
@@ -43,7 +43,7 @@ The protocol consists of immutable smart contracts deployed on Citrea Testnet:
 JuiceSwap is built and maintained by its community:
 
 - **GitHub**: [github.com/JuiceSwapxyz](https://github.com/JuiceSwapxyz)
-- **Website**: [juiceswap.xyz](https://juiceswap.xyz)
+- **Website**: [juiceswap.com](https://juiceswap.com)
 
 ## Legal Notice
 

--- a/src/liquidity.md
+++ b/src/liquidity.md
@@ -360,6 +360,6 @@ event LiquidityRemoved(
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153`](https://explorer.testnet.citrea.xyz/address/0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153) |
-| NonfungiblePositionManager | [`0x56D63E0F763b29F62bb7242420d028F86e9402E1`](https://explorer.testnet.citrea.xyz/address/0x56D63E0F763b29F62bb7242420d028F86e9402E1) |
-| UniswapV3Factory | [`0x9136D17Ec096AAd031D442a796cd5984128cF0b2`](https://explorer.testnet.citrea.xyz/address/0x9136D17Ec096AAd031D442a796cd5984128cF0b2) |
+| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
+| NonfungiblePositionManager | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
+| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |

--- a/src/overview.md
+++ b/src/overview.md
@@ -114,20 +114,20 @@ All contracts are deployed on **Citrea Testnet** (Chain ID: 5115):
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153`](https://explorer.testnet.citrea.xyz/address/0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153) |
-| JuiceSwapGovernor | [`0x205903c54C56bCED8C97f2DC250BA53d715174e9`](https://explorer.testnet.citrea.xyz/address/0x205903c54C56bCED8C97f2DC250BA53d715174e9) |
-| JuiceSwapFeeCollector | [`0xc3d817C394d55aB57f5bF0Fc5C6878ccE033E32a`](https://explorer.testnet.citrea.xyz/address/0xc3d817C394d55aB57f5bF0Fc5C6878ccE033E32a) |
-| UniswapV3Factory | [`0x9136D17Ec096AAd031D442a796cd5984128cF0b2`](https://explorer.testnet.citrea.xyz/address/0x9136D17Ec096AAd031D442a796cd5984128cF0b2) |
-| SwapRouter | [`0x2d11a82633adD5b8742311fDa0E751264d093E7f`](https://explorer.testnet.citrea.xyz/address/0x2d11a82633adD5b8742311fDa0E751264d093E7f) |
-| NonfungiblePositionManager | [`0x56D63E0F763b29F62bb7242420d028F86e9402E1`](https://explorer.testnet.citrea.xyz/address/0x56D63E0F763b29F62bb7242420d028F86e9402E1) |
+| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
+| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
+| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
+| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
+| SwapRouter | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
+| NonfungiblePositionManager | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
 
 ### JuiceDollar Protocol (Referenced)
 
 | Contract | Address |
 |----------|---------|
-| JUSD | [`0xFdB0a83d94CD65151148a131167Eb499Cb85d015`](https://explorer.testnet.citrea.xyz/address/0xFdB0a83d94CD65151148a131167Eb499Cb85d015) |
-| JUICE (Equity) | [`0x7b2A560bf72B0Dd2EAbE3271F829C2597c8420d5`](https://explorer.testnet.citrea.xyz/address/0x7b2A560bf72B0Dd2EAbE3271F829C2597c8420d5) |
-| svJUSD (SavingsVault) | [`0x9580498224551E3f2e3A04330a684BF025111C53`](https://explorer.testnet.citrea.xyz/address/0x9580498224551E3f2e3A04330a684BF025111C53) |
+| JUSD | [`0x6a850a548fdd050e8961223ec8FfCDfacEa57E39`](https://explorer.testnet.citrea.xyz/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) |
+| JUICE (Equity) | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
+| svJUSD (SavingsVault) | [`0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B`](https://explorer.testnet.citrea.xyz/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) |
 | WcBTC | [`0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93`](https://explorer.testnet.citrea.xyz/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) |
 
 ## Why JuiceSwap?

--- a/src/smart-contracts.md
+++ b/src/smart-contracts.md
@@ -63,7 +63,7 @@ The main entry point for users, handling automatic token conversions.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153`](https://explorer.testnet.citrea.xyz/address/0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153) |
+| **Address** | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
 | **Default Fee** | 3000 (0.30%) |
 | **Max Bridged Tokens** | 10 |
 
@@ -91,7 +91,7 @@ Governance contract using JUICE token voting with veto mechanism.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x205903c54C56bCED8C97f2DC250BA53d715174e9`](https://explorer.testnet.citrea.xyz/address/0x205903c54C56bCED8C97f2DC250BA53d715174e9) |
+| **Address** | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
 | **Proposal Fee** | 1,000 JUSD |
 | **Min Application Period** | 14 days |
 | **Veto Quorum** | 2% |
@@ -121,7 +121,7 @@ Automated protocol fee collection with TWAP-based frontrunning protection.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0xc3d817C394d55aB57f5bF0Fc5C6878ccE033E32a`](https://explorer.testnet.citrea.xyz/address/0xc3d817C394d55aB57f5bF0Fc5C6878ccE033E32a) |
+| **Address** | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
 | **TWAP Period** | 30 minutes (1800 seconds) |
 | **Max Slippage** | 2% (200 bps) |
 | **Block Time** | 2 seconds (Citrea) |
@@ -145,7 +145,7 @@ Creates and manages liquidity pools.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x9136D17Ec096AAd031D442a796cd5984128cF0b2`](https://explorer.testnet.citrea.xyz/address/0x9136D17Ec096AAd031D442a796cd5984128cF0b2) |
+| **Address** | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
 | **Owner** | JuiceSwapFeeCollector |
 
 ### Fee Tiers
@@ -173,7 +173,7 @@ Routes swaps through the most efficient path.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x2d11a82633adD5b8742311fDa0E751264d093E7f`](https://explorer.testnet.citrea.xyz/address/0x2d11a82633adD5b8742311fDa0E751264d093E7f) |
+| **Address** | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
 
 ---
 
@@ -193,7 +193,7 @@ Manages LP positions as NFTs (ERC-721).
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x56D63E0F763b29F62bb7242420d028F86e9402E1`](https://explorer.testnet.citrea.xyz/address/0x56D63E0F763b29F62bb7242420d028F86e9402E1) |
+| **Address** | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
 
 ---
 
@@ -207,7 +207,7 @@ The stablecoin used for trading pairs.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0xFdB0a83d94CD65151148a131167Eb499Cb85d015`](https://explorer.testnet.citrea.xyz/address/0xFdB0a83d94CD65151148a131167Eb499Cb85d015) |
+| **Address** | [`0x6a850a548fdd050e8961223ec8FfCDfacEa57E39`](https://explorer.testnet.citrea.xyz/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) |
 | **Decimals** | 18 |
 
 ### svJUSD (SavingsVaultJUSD)
@@ -216,7 +216,7 @@ Interest-bearing JUSD vault (ERC-4626). Used in pools instead of plain JUSD.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x9580498224551E3f2e3A04330a684BF025111C53`](https://explorer.testnet.citrea.xyz/address/0x9580498224551E3f2e3A04330a684BF025111C53) |
+| **Address** | [`0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B`](https://explorer.testnet.citrea.xyz/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) |
 | **Symbol** | svJUSD |
 
 ### JUICE (Equity)
@@ -225,7 +225,7 @@ Governance token for voting and fee distribution.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x7b2A560bf72B0Dd2EAbE3271F829C2597c8420d5`](https://explorer.testnet.citrea.xyz/address/0x7b2A560bf72B0Dd2EAbE3271F829C2597c8420d5) |
+| **Address** | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
 | **Decimals** | 18 |
 
 ### WcBTC (Wrapped cBTC)
@@ -243,12 +243,12 @@ Wrapped version of native cBTC for ERC-20 compatibility.
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| JuiceSwapGateway | [`0x3b59...5153`](https://explorer.testnet.citrea.xyz/address/0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153) | User-facing swap/LP interface |
-| JuiceSwapGovernor | [`0x2059...74e9`](https://explorer.testnet.citrea.xyz/address/0x205903c54C56bCED8C97f2DC250BA53d715174e9) | Governance proposals |
-| JuiceSwapFeeCollector | [`0xc3d8...E32a`](https://explorer.testnet.citrea.xyz/address/0xc3d817C394d55aB57f5bF0Fc5C6878ccE033E32a) | Fee collection & distribution |
-| UniswapV3Factory | [`0x9136...F0b2`](https://explorer.testnet.citrea.xyz/address/0x9136D17Ec096AAd031D442a796cd5984128cF0b2) | Pool creation |
-| SwapRouter | [`0x2d11...3E7f`](https://explorer.testnet.citrea.xyz/address/0x2d11a82633adD5b8742311fDa0E751264d093E7f) | Swap routing |
-| NonfungiblePositionManager | [`0x56D6...02E1`](https://explorer.testnet.citrea.xyz/address/0x56D63E0F763b29F62bb7242420d028F86e9402E1) | LP NFT management |
+| JuiceSwapGateway | [`0x8eE3...44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) | User-facing swap/LP interface |
+| JuiceSwapGovernor | [`0x8AFD...A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) | Governance proposals |
+| JuiceSwapFeeCollector | [`0xfac6...47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) | Fee collection & distribution |
+| UniswapV3Factory | [`0xdd6D...4238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) | Pool creation |
+| SwapRouter | [`0x26C1...c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) | Swap routing |
+| NonfungiblePositionManager | [`0x86e7...B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) | LP NFT management |
 
 ---
 

--- a/src/swap.md
+++ b/src/swap.md
@@ -189,6 +189,6 @@ event SwapExecuted(
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153`](https://explorer.testnet.citrea.xyz/address/0x3b59BCd4eFe392d715f4c57fA4218BFCAD5FB153) |
-| SwapRouter | [`0x2d11a82633adD5b8742311fDa0E751264d093E7f`](https://explorer.testnet.citrea.xyz/address/0x2d11a82633adD5b8742311fDa0E751264d093E7f) |
-| UniswapV3Factory | [`0x9136D17Ec096AAd031D442a796cd5984128cF0b2`](https://explorer.testnet.citrea.xyz/address/0x9136D17Ec096AAd031D442a796cd5984128cF0b2) |
+| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
+| SwapRouter | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
+| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |


### PR DESCRIPTION
## Summary

Merges develop into main with updated testnet contract addresses.

## Changes included

- All JuiceSwap contract addresses updated to latest testnet deployment
- JuiceDollar reference addresses (JUSD, JUICE, svJUSD) updated
- Documentation now reflects current deployed contracts on Citrea Testnet (Chain ID: 5115)

## PRs included

- #24 - Update contract addresses to latest testnet deployment