### PR TITLE
Add Mainnet contract addresses

### DIFF
--- a/src/governance.md
+++ b/src/governance.md
@@ -284,6 +284,17 @@ This means:
 
 ## Contract Addresses
 
+### Mainnet (Chain ID: 4114)
+
+| Contract | Address |
+|----------|---------|
+| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
+| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
+| JUICE (Equity) | [`0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4`](https://explorer.mainnet.citrea.xyz/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) |
+| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
+
+### Testnet (Chain ID: 5115)
+
 | Contract | Address |
 |----------|---------|
 | JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |

--- a/src/imprint.md
+++ b/src/imprint.md
@@ -30,7 +30,17 @@ All JuiceSwap code is open source and available at:
 
 ## Smart Contract Addresses
 
-The protocol consists of immutable smart contracts deployed on Citrea Testnet:
+The protocol consists of immutable smart contracts deployed on Citrea:
+
+### Mainnet (Chain ID: 4114)
+
+| Contract | Address |
+|----------|---------|
+| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
+| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
+| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
+
+### Testnet (Chain ID: 5115)
 
 | Contract | Address |
 |----------|---------|

--- a/src/liquidity.md
+++ b/src/liquidity.md
@@ -358,6 +358,16 @@ event LiquidityRemoved(
 
 ## Contract Addresses
 
+### Mainnet (Chain ID: 4114)
+
+| Contract | Address |
+|----------|---------|
+| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
+| NonfungiblePositionManager | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://explorer.mainnet.citrea.xyz/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) |
+| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
+
+### Testnet (Chain ID: 5115)
+
 | Contract | Address |
 |----------|---------|
 | JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |

--- a/src/overview.md
+++ b/src/overview.md
@@ -110,7 +110,18 @@ JuiceSwap is tightly integrated with the JuiceDollar protocol:
 
 ## Contract Addresses
 
-All contracts are deployed on **Citrea Testnet** (Chain ID: 5115):
+### Mainnet (Chain ID: 4114)
+
+| Contract | Address |
+|----------|---------|
+| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
+| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
+| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
+| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
+| SwapRouter | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://explorer.mainnet.citrea.xyz/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) |
+| NonfungiblePositionManager | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://explorer.mainnet.citrea.xyz/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) |
+
+### Testnet (Chain ID: 5115)
 
 | Contract | Address |
 |----------|---------|
@@ -123,12 +134,12 @@ All contracts are deployed on **Citrea Testnet** (Chain ID: 5115):
 
 ### JuiceDollar Protocol (Referenced)
 
-| Contract | Address |
-|----------|---------|
-| JUSD | [`0x6a850a548fdd050e8961223ec8FfCDfacEa57E39`](https://explorer.testnet.citrea.xyz/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) |
-| JUICE (Equity) | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
-| svJUSD (SavingsVault) | [`0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B`](https://explorer.testnet.citrea.xyz/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) |
-| WcBTC | [`0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93`](https://explorer.testnet.citrea.xyz/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) |
+| Contract | Mainnet | Testnet |
+|----------|---------|---------|
+| JUSD | [`0x0987...35C`](https://explorer.mainnet.citrea.xyz/address/0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C) | [`0x6a85...E39`](https://explorer.testnet.citrea.xyz/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) |
+| JUICE (Equity) | [`0x2A36...ae4`](https://explorer.mainnet.citrea.xyz/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) | [`0x7fa1...D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
+| svJUSD (SavingsVault) | [`0x1b70...97d`](https://explorer.mainnet.citrea.xyz/address/0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d) | [`0x802a...c7B`](https://explorer.testnet.citrea.xyz/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) |
+| WcBTC | [`0x3100...006`](https://explorer.mainnet.citrea.xyz/address/0x3100000000000000000000000000000000000006) | [`0x8d0c...d93`](https://explorer.testnet.citrea.xyz/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) |
 
 ## Why JuiceSwap?
 

--- a/src/smart-contracts.md
+++ b/src/smart-contracts.md
@@ -323,5 +323,5 @@ All source code is available on GitHub:
 
 | Network | Chain ID | Explorer |
 |---------|----------|----------|
-| **Mainnet** | 4114 | [explorer.citrea.xyz](https://explorer.mainnet.citrea.xyz) |
+| **Mainnet** | 4114 | [explorer.mainnet.citrea.xyz](https://explorer.mainnet.citrea.xyz) |
 | **Testnet** | 5115 | [explorer.testnet.citrea.xyz](https://explorer.testnet.citrea.xyz) |

--- a/src/smart-contracts.md
+++ b/src/smart-contracts.md
@@ -2,7 +2,7 @@
 
 **A technical overview of all smart contracts powering JuiceSwap.**
 
-JuiceSwap is built on a fork of Uniswap V3, with custom contracts for governance, fee collection, and JuiceDollar integration. All contracts are deployed on Citrea Testnet (Chain ID: 5115).
+JuiceSwap is built on a fork of Uniswap V3, with custom contracts for governance, fee collection, and JuiceDollar integration. All contracts are deployed on Citrea Mainnet (Chain ID: 4114) and Testnet (Chain ID: 5115).
 
 ## Contract Architecture
 
@@ -63,9 +63,13 @@ The main entry point for users, handling automatic token conversions.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
 | **Default Fee** | 3000 (0.30%) |
 | **Max Bridged Tokens** | 10 |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
+| **Testnet** | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
 
 ---
 
@@ -91,10 +95,14 @@ Governance contract using JUICE token voting with veto mechanism.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
 | **Proposal Fee** | 1,000 JUSD |
 | **Min Application Period** | 14 days |
 | **Veto Quorum** | 2% |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
+| **Testnet** | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
 
 ---
 
@@ -121,10 +129,14 @@ Automated protocol fee collection with TWAP-based frontrunning protection.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
 | **TWAP Period** | 30 minutes (1800 seconds) |
 | **Max Slippage** | 2% (200 bps) |
 | **Block Time** | 2 seconds (Citrea) |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
+| **Testnet** | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
 
 ---
 
@@ -145,8 +157,12 @@ Creates and manages liquidity pools.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
 | **Owner** | JuiceSwapFeeCollector |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
+| **Testnet** | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
 
 ### Fee Tiers
 
@@ -171,9 +187,10 @@ Routes swaps through the most efficient path.
 | `exactOutputSingle()` | Single-hop swap with exact output |
 | `exactOutput()` | Multi-hop swap with exact output |
 
-| Property | Value |
-|----------|-------|
-| **Address** | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://explorer.mainnet.citrea.xyz/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) |
+| **Testnet** | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
 
 ---
 
@@ -191,9 +208,10 @@ Manages LP positions as NFTs (ERC-721).
 | `collect()` | Collect earned fees |
 | `positions()` | Get position details |
 
-| Property | Value |
-|----------|-------|
-| **Address** | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://explorer.mainnet.citrea.xyz/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) |
+| **Testnet** | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
 
 ---
 
@@ -207,8 +225,12 @@ The stablecoin used for trading pairs.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x6a850a548fdd050e8961223ec8FfCDfacEa57E39`](https://explorer.testnet.citrea.xyz/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) |
 | **Decimals** | 18 |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C`](https://explorer.mainnet.citrea.xyz/address/0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C) |
+| **Testnet** | [`0x6a850a548fdd050e8961223ec8FfCDfacEa57E39`](https://explorer.testnet.citrea.xyz/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) |
 
 ### svJUSD (SavingsVaultJUSD)
 
@@ -216,8 +238,12 @@ Interest-bearing JUSD vault (ERC-4626). Used in pools instead of plain JUSD.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B`](https://explorer.testnet.citrea.xyz/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) |
 | **Symbol** | svJUSD |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d`](https://explorer.mainnet.citrea.xyz/address/0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d) |
+| **Testnet** | [`0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B`](https://explorer.testnet.citrea.xyz/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) |
 
 ### JUICE (Equity)
 
@@ -225,8 +251,12 @@ Governance token for voting and fee distribution.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
 | **Decimals** | 18 |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4`](https://explorer.mainnet.citrea.xyz/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) |
+| **Testnet** | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
 
 ### WcBTC (Wrapped cBTC)
 
@@ -234,12 +264,29 @@ Wrapped version of native cBTC for ERC-20 compatibility.
 
 | Property | Value |
 |----------|-------|
-| **Address** | [`0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93`](https://explorer.testnet.citrea.xyz/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) |
 | **Decimals** | 18 |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x3100000000000000000000000000000000000006`](https://explorer.mainnet.citrea.xyz/address/0x3100000000000000000000000000000000000006) |
+| **Testnet** | [`0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93`](https://explorer.testnet.citrea.xyz/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) |
 
 ---
 
 ## Contract Summary
+
+### Mainnet (Chain ID: 4114)
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| JuiceSwapGateway | [`0xAFcf...ab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) | User-facing swap/LP interface |
+| JuiceSwapGovernor | [`0x51f3...7ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) | Governance proposals |
+| JuiceSwapFeeCollector | [`0xD2D6...97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) | Fee collection & distribution |
+| UniswapV3Factory | [`0xd809...e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) | Pool creation |
+| SwapRouter | [`0x565e...cF8`](https://explorer.mainnet.citrea.xyz/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) | Swap routing |
+| NonfungiblePositionManager | [`0x3D38...568`](https://explorer.mainnet.citrea.xyz/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) | LP NFT management |
+
+### Testnet (Chain ID: 5115)
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
@@ -274,6 +321,7 @@ All source code is available on GitHub:
 | [JuiceSwapxyz/v3-core](https://github.com/JuiceSwapxyz/v3-core) | Factory, Pools (Uniswap V3 fork) |
 | [JuiceSwapxyz/v3-periphery](https://github.com/JuiceSwapxyz/v3-periphery) | Router, Position Manager |
 
-**Network:** Citrea Testnet (Chain ID: 5115)
-
-**Explorer:** [explorer.testnet.citrea.xyz](https://explorer.testnet.citrea.xyz)
+| Network | Chain ID | Explorer |
+|---------|----------|----------|
+| **Mainnet** | 4114 | [explorer.citrea.xyz](https://explorer.mainnet.citrea.xyz) |
+| **Testnet** | 5115 | [explorer.testnet.citrea.xyz](https://explorer.testnet.citrea.xyz) |

--- a/src/swap.md
+++ b/src/swap.md
@@ -187,6 +187,16 @@ event SwapExecuted(
 
 ## Contract Addresses
 
+### Mainnet (Chain ID: 4114)
+
+| Contract | Address |
+|----------|---------|
+| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
+| SwapRouter | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://explorer.mainnet.citrea.xyz/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) |
+| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
+
+### Testnet (Chain ID: 5115)
+
 | Contract | Address |
 |----------|---------|
 | JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |


### PR DESCRIPTION
## Summary
- Add Mainnet (Chain ID: 4114) contract addresses alongside existing Testnet addresses
- Update smart-contracts.md with complete Mainnet/Testnet tables
- Update overview.md, liquidity.md, swap.md, governance.md, imprint.md
- Use correct explorer URLs: explorer.mainnet.citrea.xyz for Mainnet

## Test plan
- [ ] Verify all Mainnet addresses are correct
- [ ] Verify all explorer links work
- [ ] Run local build to check for markdown issues