### PR TITLE
docs: Add complete contract documentation for V2, infrastructure, launchpad and bridge

### DIFF
--- a/src/smart-contracts.md
+++ b/src/smart-contracts.md
@@ -2,7 +2,7 @@
 
 **A technical overview of all smart contracts powering JuiceSwap.**
 
-JuiceSwap is built on a fork of Uniswap V3, with custom contracts for governance, fee collection, and JuiceDollar integration. All contracts are deployed on Citrea Mainnet (Chain ID: 4114) and Testnet (Chain ID: 5115).
+JuiceSwap is built on forks of Uniswap V2 and V3, with custom contracts for governance, fee collection, launchpad, and JuiceDollar integration. All contracts are deployed on Citrea Mainnet (Chain ID: 4114) and Testnet (Chain ID: 5115).
 
 ## Contract Architecture
 
@@ -18,10 +18,10 @@ JuiceSwap is built on a fork of Uniswap V3, with custom contracts for governance
 │   └─────────────────────────────────────────────────────────┘   │
 │                              │                                   │
 │   ┌──────────────────────────┼──────────────────────────────┐   │
-│   │                Uniswap V3 Core                           │   │
+│   │           Uniswap V2 + V3 Core                           │   │
 │   │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐      │   │
-│   │  │   Factory   │  │   Pools     │  │ Position    │      │   │
-│   │  │             │  │             │  │ Manager     │      │   │
+│   │  │  V2/V3      │  │   Pools     │  │ Position    │      │   │
+│   │  │  Factory    │  │             │  │ Manager     │      │   │
 │   │  └─────────────┘  └─────────────┘  └─────────────┘      │   │
 │   └─────────────────────────────────────────────────────────┘   │
 │                              │                                   │
@@ -30,6 +30,14 @@ JuiceSwap is built on a fork of Uniswap V3, with custom contracts for governance
 │   │  ┌─────────────────┐  ┌─────────────────┐               │   │
 │   │  │  JuiceSwap      │  │  JuiceSwap      │               │   │
 │   │  │  Governor       │  │  FeeCollector   │               │   │
+│   │  └─────────────────┘  └─────────────────┘               │   │
+│   └─────────────────────────────────────────────────────────┘   │
+│                              │                                   │
+│   ┌──────────────────────────┼──────────────────────────────┐   │
+│   │              Launchpad & Bridging                        │   │
+│   │  ┌─────────────────┐  ┌─────────────────┐               │   │
+│   │  │  TokenFactory   │  │  LayerZero      │               │   │
+│   │  │  (Bonding Curve)│  │  Bridge (L0)    │               │   │
 │   │  └─────────────────┘  └─────────────────┘               │   │
 │   └─────────────────────────────────────────────────────────┘   │
 │                                                                  │
@@ -215,6 +223,253 @@ Manages LP positions as NFTs (ERC-721).
 
 ---
 
+### QuoterV2
+
+Provides price quotes for swaps without executing them.
+
+**Key Functions:**
+
+| Function | Description |
+|----------|-------------|
+| `quoteExactInputSingle()` | Quote for single-hop swap with exact input |
+| `quoteExactInput()` | Quote for multi-hop swap with exact input |
+| `quoteExactOutputSingle()` | Quote for single-hop swap with exact output |
+| `quoteExactOutput()` | Quote for multi-hop swap with exact output |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425`](https://explorer.mainnet.citrea.xyz/address/0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425) |
+| **Testnet** | [`0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d`](https://explorer.testnet.citrea.xyz/address/0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d) |
+
+---
+
+### TickLens
+
+Batch fetches tick data for pools.
+
+**Key Functions:**
+
+| Function | Description |
+|----------|-------------|
+| `getPopulatedTicksInWord()` | Get all initialized ticks in a word |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0xD9d430f27F922A3316d22Cd9d58558f45Dad8012`](https://explorer.mainnet.citrea.xyz/address/0xD9d430f27F922A3316d22Cd9d58558f45Dad8012) |
+| **Testnet** | [`0xa0Fe847227eE5076bC5D1D3c605261837fa047fB`](https://explorer.testnet.citrea.xyz/address/0xa0Fe847227eE5076bC5D1D3c605261837fa047fB) |
+
+---
+
+### V3Migrator
+
+Migrates liquidity from Uniswap V2 to V3.
+
+**Key Functions:**
+
+| Function | Description |
+|----------|-------------|
+| `migrate()` | Migrate V2 LP tokens to V3 position |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6`](https://explorer.mainnet.citrea.xyz/address/0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6) |
+| **Testnet** | [`0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8`](https://explorer.testnet.citrea.xyz/address/0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8) |
+
+---
+
+### V3Staker
+
+Liquidity mining rewards for V3 positions.
+
+**Key Functions:**
+
+| Function | Description |
+|----------|-------------|
+| `createIncentive()` | Create a new staking incentive |
+| `stakeToken()` | Stake an LP NFT |
+| `unstakeToken()` | Unstake an LP NFT |
+| `claimReward()` | Claim earned rewards |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0xB511028582FDEe8AC66b524630Cc85e457f66Aa1`](https://explorer.mainnet.citrea.xyz/address/0xB511028582FDEe8AC66b524630Cc85e457f66Aa1) |
+| **Testnet** | [`0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE`](https://explorer.testnet.citrea.xyz/address/0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE) |
+
+---
+
+### Multicall2
+
+Batch multiple contract calls in a single transaction.
+
+**Key Functions:**
+
+| Function | Description |
+|----------|-------------|
+| `aggregate()` | Execute multiple calls, revert on failure |
+| `tryAggregate()` | Execute multiple calls, return success status |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c`](https://explorer.mainnet.citrea.xyz/address/0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c) |
+| **Testnet** | [`0xC1bD4864F267f8B032224817d33A7b53eD866F5e`](https://explorer.testnet.citrea.xyz/address/0xC1bD4864F267f8B032224817d33A7b53eD866F5e) |
+
+---
+
+### ProxyAdmin
+
+Admin contract for upgradeable proxies (e.g., NFT position descriptor).
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031`](https://explorer.mainnet.citrea.xyz/address/0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031) |
+| **Testnet** | [`0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4`](https://explorer.testnet.citrea.xyz/address/0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4) |
+
+---
+
+## Uniswap V2 Contracts
+
+JuiceSwap includes Uniswap V2 contracts for simpler AMM pools with constant product formula.
+
+### UniswapV2Factory
+
+Creates and manages V2 liquidity pools.
+
+**Key Functions:**
+
+| Function | Description |
+|----------|-------------|
+| `createPair()` | Deploy a new V2 pair |
+| `getPair()` | Get pair address for token pair |
+| `allPairs()` | Get pair by index |
+| `allPairsLength()` | Total number of pairs |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x400B27260bc8BbBF740e25B29a24EDf175d9fE56`](https://explorer.mainnet.citrea.xyz/address/0x400B27260bc8BbBF740e25B29a24EDf175d9fE56) |
+| **Testnet** | [`0xfc271758732F5eD3ddF19727B7E29BFC3325370d`](https://explorer.testnet.citrea.xyz/address/0xfc271758732F5eD3ddF19727B7E29BFC3325370d) |
+
+---
+
+### UniswapV2Router02
+
+Routes swaps and liquidity operations for V2 pools.
+
+**Key Functions:**
+
+| Function | Description |
+|----------|-------------|
+| `swapExactTokensForTokens()` | Swap exact input for minimum output |
+| `swapTokensForExactTokens()` | Swap maximum input for exact output |
+| `addLiquidity()` | Add liquidity to a pair |
+| `removeLiquidity()` | Remove liquidity from a pair |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x6BDea31C89E0A202cE84b5752BB2e827B39984ae`](https://explorer.mainnet.citrea.xyz/address/0x6BDea31C89E0A202cE84b5752BB2e827B39984ae) |
+| **Testnet** | [`0x37164703eF51EcB49C9a565C233a277003aE483f`](https://explorer.testnet.citrea.xyz/address/0x37164703eF51EcB49C9a565C233a277003aE483f) |
+
+---
+
+## NFT Position Descriptor Contracts
+
+These contracts generate on-chain SVG artwork and metadata for LP position NFTs.
+
+### NFTDescriptorLibrary
+
+Library for generating SVG artwork.
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6`](https://explorer.mainnet.citrea.xyz/address/0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6) |
+| **Testnet** | [`0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef`](https://explorer.testnet.citrea.xyz/address/0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef) |
+
+### NonfungibleTokenPositionDescriptor
+
+Generates token URI metadata for position NFTs.
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x321c3C687D65C22A25f1e461e2568156adfD5D9C`](https://explorer.mainnet.citrea.xyz/address/0x321c3C687D65C22A25f1e461e2568156adfD5D9C) |
+| **Testnet** | [`0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD`](https://explorer.testnet.citrea.xyz/address/0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD) |
+
+### DescriptorProxy
+
+Upgradeable proxy for the position descriptor.
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0x2e6D1f833a7951d02A47f244bA5F429699B87E4f`](https://explorer.mainnet.citrea.xyz/address/0x2e6D1f833a7951d02A47f244bA5F429699B87E4f) |
+| **Testnet** | [`0x6b8e06186725e41EC05045A957bA78A336b3dd70`](https://explorer.testnet.citrea.xyz/address/0x6b8e06186725e41EC05045A957bA78A336b3dd70) |
+
+---
+
+## Launchpad Contracts
+
+The JuiceSwap Launchpad enables fair token launches with bonding curve mechanics.
+
+### TokenFactory
+
+Creates new tokens with bonding curve pricing that graduate to V2 pools.
+
+**Key Features:**
+- Bonding curve token creation
+- Automatic graduation to Uniswap V2 when market cap threshold reached
+- Built-in fee mechanism
+
+**Key Functions:**
+
+| Function | Description |
+|----------|-------------|
+| `createToken()` | Deploy a new bonding curve token |
+| `buy()` | Buy tokens on the bonding curve |
+| `sell()` | Sell tokens on the bonding curve |
+| `graduate()` | Graduate token to V2 pool |
+
+| Property | Value |
+|----------|-------|
+| **Graduation Threshold** | ~12,750 JUSD collected |
+| **Reserved for DEX** | 20.69% of supply |
+| **Fee** | 1% (100 bps) |
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0xF5E06d37091a252A3Ae6BFd575D97635625028b9`](https://explorer.mainnet.citrea.xyz/address/0xF5E06d37091a252A3Ae6BFd575D97635625028b9) |
+| **Testnet** | [`0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4`](https://explorer.testnet.citrea.xyz/address/0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4) |
+
+---
+
+### BondingCurveToken (Implementation)
+
+Template contract for bonding curve tokens.
+
+| Network | Address |
+|---------|---------|
+| **Mainnet** | [`0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c`](https://explorer.mainnet.citrea.xyz/address/0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c) |
+| **Testnet** | [`0xC46706007351AD7853159170fCC0489CCD04643D`](https://explorer.testnet.citrea.xyz/address/0xC46706007351AD7853159170fCC0489CCD04643D) |
+
+---
+
+## LayerZero Bridge Contracts (Mainnet Only)
+
+JuiceSwap integrates with LayerZero for cross-chain token bridging from Ethereum.
+
+### Bridged Tokens
+
+| Token | Address | Description |
+|-------|---------|-------------|
+| **USDC (L0)** | [`0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839`](https://explorer.mainnet.citrea.xyz/address/0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839) | LayerZero bridged USDC |
+| **USDT (L0)** | [`0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4`](https://explorer.mainnet.citrea.xyz/address/0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4) | LayerZero bridged USDT |
+| **WBTC.e** | [`0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d`](https://explorer.mainnet.citrea.xyz/address/0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d) | LayerZero bridged WBTC (OFT) |
+
+### OFT Adapters
+
+| Contract | Address | Description |
+|----------|---------|-------------|
+| **USDC OFT Adapter** | [`0x41710804caB0974638E1504DB723D7bddec22e30`](https://explorer.mainnet.citrea.xyz/address/0x41710804caB0974638E1504DB723D7bddec22e30) | Bridge adapter for USDC |
+| **USDT OFT Adapter** | [`0xF8b5983BFa11dc763184c96065D508AE1502C030`](https://explorer.mainnet.citrea.xyz/address/0xF8b5983BFa11dc763184c96065D508AE1502C030) | Bridge adapter for USDT |
+
+---
+
 ## JuiceDollar Integration
 
 JuiceSwap integrates with JuiceDollar contracts:
@@ -277,25 +532,123 @@ Wrapped version of native cBTC for ERC-20 compatibility.
 
 ### Mainnet (Chain ID: 4114)
 
+#### JuiceSwap Core
+
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| JuiceSwapGateway | [`0xAFcf...ab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) | User-facing swap/LP interface |
-| JuiceSwapGovernor | [`0x51f3...7ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) | Governance proposals |
-| JuiceSwapFeeCollector | [`0xD2D6...97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) | Fee collection & distribution |
-| UniswapV3Factory | [`0xd809...e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) | Pool creation |
-| SwapRouter | [`0x565e...cF8`](https://explorer.mainnet.citrea.xyz/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) | Swap routing |
-| NonfungiblePositionManager | [`0x3D38...568`](https://explorer.mainnet.citrea.xyz/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) | LP NFT management |
+| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) | User-facing swap/LP interface |
+| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) | Governance proposals |
+| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) | Fee collection & distribution |
+
+#### Uniswap V3
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) | V3 pool creation |
+| SwapRouter | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://explorer.mainnet.citrea.xyz/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) | V3 swap routing |
+| NonfungiblePositionManager | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://explorer.mainnet.citrea.xyz/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) | LP NFT management |
+| QuoterV2 | [`0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425`](https://explorer.mainnet.citrea.xyz/address/0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425) | Price quotes |
+| TickLens | [`0xD9d430f27F922A3316d22Cd9d58558f45Dad8012`](https://explorer.mainnet.citrea.xyz/address/0xD9d430f27F922A3316d22Cd9d58558f45Dad8012) | Tick data fetching |
+| V3Migrator | [`0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6`](https://explorer.mainnet.citrea.xyz/address/0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6) | V2→V3 migration |
+| V3Staker | [`0xB511028582FDEe8AC66b524630Cc85e457f66Aa1`](https://explorer.mainnet.citrea.xyz/address/0xB511028582FDEe8AC66b524630Cc85e457f66Aa1) | Liquidity mining |
+
+#### Uniswap V2
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| UniswapV2Factory | [`0x400B27260bc8BbBF740e25B29a24EDf175d9fE56`](https://explorer.mainnet.citrea.xyz/address/0x400B27260bc8BbBF740e25B29a24EDf175d9fE56) | V2 pair creation |
+| UniswapV2Router02 | [`0x6BDea31C89E0A202cE84b5752BB2e827B39984ae`](https://explorer.mainnet.citrea.xyz/address/0x6BDea31C89E0A202cE84b5752BB2e827B39984ae) | V2 swap routing |
+
+#### Infrastructure
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| Multicall2 | [`0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c`](https://explorer.mainnet.citrea.xyz/address/0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c) | Batch calls |
+| ProxyAdmin | [`0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031`](https://explorer.mainnet.citrea.xyz/address/0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031) | Proxy administration |
+| NFTDescriptorLibrary | [`0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6`](https://explorer.mainnet.citrea.xyz/address/0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6) | NFT SVG generation |
+| PositionDescriptor | [`0x321c3C687D65C22A25f1e461e2568156adfD5D9C`](https://explorer.mainnet.citrea.xyz/address/0x321c3C687D65C22A25f1e461e2568156adfD5D9C) | NFT metadata |
+| DescriptorProxy | [`0x2e6D1f833a7951d02A47f244bA5F429699B87E4f`](https://explorer.mainnet.citrea.xyz/address/0x2e6D1f833a7951d02A47f244bA5F429699B87E4f) | Upgradeable descriptor |
+
+#### Launchpad
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| TokenFactory | [`0xF5E06d37091a252A3Ae6BFd575D97635625028b9`](https://explorer.mainnet.citrea.xyz/address/0xF5E06d37091a252A3Ae6BFd575D97635625028b9) | Bonding curve tokens |
+| BondingCurveToken | [`0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c`](https://explorer.mainnet.citrea.xyz/address/0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c) | Token implementation |
+
+#### Tokens
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| JUSD | [`0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C`](https://explorer.mainnet.citrea.xyz/address/0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C) | Stablecoin |
+| svJUSD | [`0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d`](https://explorer.mainnet.citrea.xyz/address/0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d) | Savings vault |
+| JUICE | [`0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4`](https://explorer.mainnet.citrea.xyz/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) | Governance token |
+| WcBTC | [`0x3100000000000000000000000000000000000006`](https://explorer.mainnet.citrea.xyz/address/0x3100000000000000000000000000000000000006) | Wrapped cBTC |
+
+#### LayerZero Bridge
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| USDC (L0) | [`0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839`](https://explorer.mainnet.citrea.xyz/address/0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839) | Bridged USDC |
+| USDC OFT Adapter | [`0x41710804caB0974638E1504DB723D7bddec22e30`](https://explorer.mainnet.citrea.xyz/address/0x41710804caB0974638E1504DB723D7bddec22e30) | USDC bridge adapter |
+| USDT (L0) | [`0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4`](https://explorer.mainnet.citrea.xyz/address/0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4) | Bridged USDT |
+| USDT OFT Adapter | [`0xF8b5983BFa11dc763184c96065D508AE1502C030`](https://explorer.mainnet.citrea.xyz/address/0xF8b5983BFa11dc763184c96065D508AE1502C030) | USDT bridge adapter |
+| WBTC.e | [`0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d`](https://explorer.mainnet.citrea.xyz/address/0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d) | Bridged WBTC |
 
 ### Testnet (Chain ID: 5115)
 
+#### JuiceSwap Core
+
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| JuiceSwapGateway | [`0x8eE3...44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) | User-facing swap/LP interface |
-| JuiceSwapGovernor | [`0x8AFD...A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) | Governance proposals |
-| JuiceSwapFeeCollector | [`0xfac6...47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) | Fee collection & distribution |
-| UniswapV3Factory | [`0xdd6D...4238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) | Pool creation |
-| SwapRouter | [`0x26C1...c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) | Swap routing |
-| NonfungiblePositionManager | [`0x86e7...B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) | LP NFT management |
+| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) | User-facing swap/LP interface |
+| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) | Governance proposals |
+| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) | Fee collection & distribution |
+
+#### Uniswap V3
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) | V3 pool creation |
+| SwapRouter | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) | V3 swap routing |
+| NonfungiblePositionManager | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) | LP NFT management |
+| QuoterV2 | [`0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d`](https://explorer.testnet.citrea.xyz/address/0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d) | Price quotes |
+| TickLens | [`0xa0Fe847227eE5076bC5D1D3c605261837fa047fB`](https://explorer.testnet.citrea.xyz/address/0xa0Fe847227eE5076bC5D1D3c605261837fa047fB) | Tick data fetching |
+| V3Migrator | [`0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8`](https://explorer.testnet.citrea.xyz/address/0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8) | V2→V3 migration |
+| V3Staker | [`0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE`](https://explorer.testnet.citrea.xyz/address/0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE) | Liquidity mining |
+
+#### Uniswap V2
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| UniswapV2Factory | [`0xfc271758732F5eD3ddF19727B7E29BFC3325370d`](https://explorer.testnet.citrea.xyz/address/0xfc271758732F5eD3ddF19727B7E29BFC3325370d) | V2 pair creation |
+| UniswapV2Router02 | [`0x37164703eF51EcB49C9a565C233a277003aE483f`](https://explorer.testnet.citrea.xyz/address/0x37164703eF51EcB49C9a565C233a277003aE483f) | V2 swap routing |
+
+#### Infrastructure
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| Multicall2 | [`0xC1bD4864F267f8B032224817d33A7b53eD866F5e`](https://explorer.testnet.citrea.xyz/address/0xC1bD4864F267f8B032224817d33A7b53eD866F5e) | Batch calls |
+| ProxyAdmin | [`0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4`](https://explorer.testnet.citrea.xyz/address/0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4) | Proxy administration |
+| NFTDescriptorLibrary | [`0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef`](https://explorer.testnet.citrea.xyz/address/0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef) | NFT SVG generation |
+| PositionDescriptor | [`0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD`](https://explorer.testnet.citrea.xyz/address/0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD) | NFT metadata |
+| DescriptorProxy | [`0x6b8e06186725e41EC05045A957bA78A336b3dd70`](https://explorer.testnet.citrea.xyz/address/0x6b8e06186725e41EC05045A957bA78A336b3dd70) | Upgradeable descriptor |
+
+#### Launchpad
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| TokenFactory | [`0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4`](https://explorer.testnet.citrea.xyz/address/0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4) | Bonding curve tokens |
+| BondingCurveToken | [`0xC46706007351AD7853159170fCC0489CCD04643D`](https://explorer.testnet.citrea.xyz/address/0xC46706007351AD7853159170fCC0489CCD04643D) | Token implementation |
+
+#### Tokens
+
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| JUSD | [`0x6a850a548fdd050e8961223ec8FfCDfacEa57E39`](https://explorer.testnet.citrea.xyz/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) | Stablecoin |
+| svJUSD | [`0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B`](https://explorer.testnet.citrea.xyz/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) | Savings vault |
+| JUICE | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) | Governance token |
+| WcBTC | [`0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93`](https://explorer.testnet.citrea.xyz/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) | Wrapped cBTC |
 
 ---
 
@@ -318,8 +671,12 @@ All source code is available on GitHub:
 | Repository | Description |
 |------------|-------------|
 | [JuiceSwapxyz/smart-contracts](https://github.com/JuiceSwapxyz/smart-contracts) | Gateway, Governor, FeeCollector |
-| [JuiceSwapxyz/v3-core](https://github.com/JuiceSwapxyz/v3-core) | Factory, Pools (Uniswap V3 fork) |
-| [JuiceSwapxyz/v3-periphery](https://github.com/JuiceSwapxyz/v3-periphery) | Router, Position Manager |
+| [JuiceSwapxyz/v3-core](https://github.com/JuiceSwapxyz/v3-core) | V3 Factory, Pools (Uniswap V3 fork) |
+| [JuiceSwapxyz/v3-periphery](https://github.com/JuiceSwapxyz/v3-periphery) | V3 Router, Position Manager, Quoter |
+| [JuiceSwapxyz/v2-core](https://github.com/JuiceSwapxyz/v2-core) | V2 Factory, Pairs (Uniswap V2 fork) |
+| [JuiceSwapxyz/v2-periphery](https://github.com/JuiceSwapxyz/v2-periphery) | V2 Router |
+| [JuiceSwapxyz/deploy-v3](https://github.com/JuiceSwapxyz/deploy-v3) | Deployment scripts |
+| [JuiceSwapxyz/launchpad](https://github.com/JuiceSwapxyz/launchpad) | TokenFactory, BondingCurveToken |
 
 | Network | Chain ID | Explorer |
 |---------|----------|----------|


### PR DESCRIPTION
## Summary

- Add **18 missing contracts** to the smart-contracts documentation
- Covers both **Mainnet (4114)** and **Testnet (5115)**
- All addresses verified against local deployment files

### Added Contracts

#### Uniswap V2 Contracts
- UniswapV2Factory
- UniswapV2Router02

#### V3 Infrastructure Contracts
- QuoterV2
- TickLens
- V3Migrator
- V3Staker
- Multicall2
- ProxyAdmin

#### NFT Descriptor Contracts
- NFTDescriptorLibrary
- NonfungibleTokenPositionDescriptor
- DescriptorProxy

#### Launchpad Contracts
- TokenFactory
- BondingCurveToken (Implementation)

#### LayerZero Bridge Contracts (Mainnet only)
- USDC (L0)
- USDC OFT Adapter
- USDT (L0)
- USDT OFT Adapter
- WBTC.e OFT

### Other Changes
- Updated architecture diagram to include V2 and Launchpad/Bridge layer
- Updated contract summary tables with categorized sections
- Added source code references for all repositories

## Test plan

- [x] Build documentation successfully (`yarn build`)
- [ ] Review all contract addresses match deployment files
- [ ] Verify explorer links work correctly