### PR TITLE
Update Citrea RPC and explorer URLs to citreascan.com

### DIFF
--- a/src/governance.md
+++ b/src/governance.md
@@ -288,16 +288,16 @@ This means:
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
-| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
-| JUICE (Equity) | [`0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4`](https://explorer.mainnet.citrea.xyz/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) |
-| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
+| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://citreascan.com/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
+| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://citreascan.com/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
+| JUICE (Equity) | [`0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4`](https://citreascan.com/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) |
+| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://citreascan.com/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
 
 ### Testnet (Chain ID: 5115)
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
-| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
-| JUICE (Equity) | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
-| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
+| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://testnet.citreascan.com/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
+| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://testnet.citreascan.com/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
+| JUICE (Equity) | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://testnet.citreascan.com/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
+| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://testnet.citreascan.com/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |

--- a/src/imprint.md
+++ b/src/imprint.md
@@ -36,17 +36,17 @@ The protocol consists of immutable smart contracts deployed on Citrea:
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
-| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
-| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
+| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://citreascan.com/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
+| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://citreascan.com/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
+| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://citreascan.com/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
 
 ### Testnet (Chain ID: 5115)
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
-| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
-| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
+| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://testnet.citreascan.com/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
+| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://testnet.citreascan.com/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
+| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://testnet.citreascan.com/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
 
 ## Community
 

--- a/src/liquidity.md
+++ b/src/liquidity.md
@@ -362,14 +362,14 @@ event LiquidityRemoved(
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
-| NonfungiblePositionManager | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://explorer.mainnet.citrea.xyz/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) |
-| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
+| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://citreascan.com/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
+| NonfungiblePositionManager | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://citreascan.com/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) |
+| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://citreascan.com/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
 
 ### Testnet (Chain ID: 5115)
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
-| NonfungiblePositionManager | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
-| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
+| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://testnet.citreascan.com/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
+| NonfungiblePositionManager | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://testnet.citreascan.com/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
+| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://testnet.citreascan.com/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |

--- a/src/overview.md
+++ b/src/overview.md
@@ -114,32 +114,32 @@ JuiceSwap is tightly integrated with the JuiceDollar protocol:
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
-| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
-| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
-| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
-| SwapRouter | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://explorer.mainnet.citrea.xyz/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) |
-| NonfungiblePositionManager | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://explorer.mainnet.citrea.xyz/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) |
+| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://citreascan.com/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
+| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://citreascan.com/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
+| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://citreascan.com/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
+| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://citreascan.com/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
+| SwapRouter | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://citreascan.com/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) |
+| NonfungiblePositionManager | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://citreascan.com/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) |
 
 ### Testnet (Chain ID: 5115)
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
-| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
-| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
-| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
-| SwapRouter | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
-| NonfungiblePositionManager | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
+| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://testnet.citreascan.com/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
+| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://testnet.citreascan.com/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
+| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://testnet.citreascan.com/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
+| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://testnet.citreascan.com/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
+| SwapRouter | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://testnet.citreascan.com/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
+| NonfungiblePositionManager | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://testnet.citreascan.com/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
 
 ### JuiceDollar Protocol (Referenced)
 
 | Contract | Mainnet | Testnet |
 |----------|---------|---------|
-| JUSD | [`0x0987...35C`](https://explorer.mainnet.citrea.xyz/address/0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C) | [`0x6a85...E39`](https://explorer.testnet.citrea.xyz/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) |
-| JUICE (Equity) | [`0x2A36...ae4`](https://explorer.mainnet.citrea.xyz/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) | [`0x7fa1...D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
-| svJUSD (SavingsVault) | [`0x1b70...97d`](https://explorer.mainnet.citrea.xyz/address/0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d) | [`0x802a...c7B`](https://explorer.testnet.citrea.xyz/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) |
-| WcBTC | [`0x3100...006`](https://explorer.mainnet.citrea.xyz/address/0x3100000000000000000000000000000000000006) | [`0x8d0c...d93`](https://explorer.testnet.citrea.xyz/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) |
+| JUSD | [`0x0987...35C`](https://citreascan.com/address/0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C) | [`0x6a85...E39`](https://testnet.citreascan.com/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) |
+| JUICE (Equity) | [`0x2A36...ae4`](https://citreascan.com/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) | [`0x7fa1...D5E`](https://testnet.citreascan.com/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
+| svJUSD (SavingsVault) | [`0x1b70...97d`](https://citreascan.com/address/0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d) | [`0x802a...c7B`](https://testnet.citreascan.com/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) |
+| WcBTC | [`0x3100...006`](https://citreascan.com/address/0x3100000000000000000000000000000000000006) | [`0x8d0c...d93`](https://testnet.citreascan.com/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) |
 
 ## Why JuiceSwap?
 
@@ -173,4 +173,4 @@ JuiceSwap is tightly integrated with the JuiceDollar protocol:
 - **App**: [bapp.juiceswap.com](https://bapp.juiceswap.com)
 - **GitHub**: [github.com/JuiceSwapxyz](https://github.com/JuiceSwapxyz)
 - **JuiceDollar Docs**: [docs.juicedollar.com](https://docs.juicedollar.com)
-- **Explorer**: [explorer.testnet.citrea.xyz](https://explorer.testnet.citrea.xyz)
+- **Explorer**: [explorer.testnet.citrea.xyz](https://testnet.citreascan.com)

--- a/src/smart-contracts.md
+++ b/src/smart-contracts.md
@@ -76,8 +76,8 @@ The main entry point for users, handling automatic token conversions.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
-| **Testnet** | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
+| **Mainnet** | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://citreascan.com/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
+| **Testnet** | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://testnet.citreascan.com/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
 
 ---
 
@@ -109,8 +109,8 @@ Governance contract using JUICE token voting with veto mechanism.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
-| **Testnet** | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
+| **Mainnet** | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://citreascan.com/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) |
+| **Testnet** | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://testnet.citreascan.com/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) |
 
 ---
 
@@ -143,8 +143,8 @@ Automated protocol fee collection with TWAP-based frontrunning protection.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
-| **Testnet** | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
+| **Mainnet** | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://citreascan.com/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) |
+| **Testnet** | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://testnet.citreascan.com/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) |
 
 ---
 
@@ -169,8 +169,8 @@ Creates and manages liquidity pools.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
-| **Testnet** | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
+| **Mainnet** | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://citreascan.com/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
+| **Testnet** | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://testnet.citreascan.com/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
 
 ### Fee Tiers
 
@@ -197,8 +197,8 @@ Routes swaps through the most efficient path.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://explorer.mainnet.citrea.xyz/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) |
-| **Testnet** | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
+| **Mainnet** | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://citreascan.com/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) |
+| **Testnet** | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://testnet.citreascan.com/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
 
 ---
 
@@ -218,8 +218,8 @@ Manages LP positions as NFTs (ERC-721).
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://explorer.mainnet.citrea.xyz/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) |
-| **Testnet** | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
+| **Mainnet** | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://citreascan.com/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) |
+| **Testnet** | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://testnet.citreascan.com/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) |
 
 ---
 
@@ -238,8 +238,8 @@ Provides price quotes for swaps without executing them.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425`](https://explorer.mainnet.citrea.xyz/address/0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425) |
-| **Testnet** | [`0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d`](https://explorer.testnet.citrea.xyz/address/0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d) |
+| **Mainnet** | [`0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425`](https://citreascan.com/address/0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425) |
+| **Testnet** | [`0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d`](https://testnet.citreascan.com/address/0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d) |
 
 ---
 
@@ -255,8 +255,8 @@ Batch fetches tick data for pools.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0xD9d430f27F922A3316d22Cd9d58558f45Dad8012`](https://explorer.mainnet.citrea.xyz/address/0xD9d430f27F922A3316d22Cd9d58558f45Dad8012) |
-| **Testnet** | [`0xa0Fe847227eE5076bC5D1D3c605261837fa047fB`](https://explorer.testnet.citrea.xyz/address/0xa0Fe847227eE5076bC5D1D3c605261837fa047fB) |
+| **Mainnet** | [`0xD9d430f27F922A3316d22Cd9d58558f45Dad8012`](https://citreascan.com/address/0xD9d430f27F922A3316d22Cd9d58558f45Dad8012) |
+| **Testnet** | [`0xa0Fe847227eE5076bC5D1D3c605261837fa047fB`](https://testnet.citreascan.com/address/0xa0Fe847227eE5076bC5D1D3c605261837fa047fB) |
 
 ---
 
@@ -272,8 +272,8 @@ Migrates liquidity from Uniswap V2 to V3.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6`](https://explorer.mainnet.citrea.xyz/address/0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6) |
-| **Testnet** | [`0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8`](https://explorer.testnet.citrea.xyz/address/0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8) |
+| **Mainnet** | [`0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6`](https://citreascan.com/address/0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6) |
+| **Testnet** | [`0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8`](https://testnet.citreascan.com/address/0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8) |
 
 ---
 
@@ -292,8 +292,8 @@ Liquidity mining rewards for V3 positions.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0xB511028582FDEe8AC66b524630Cc85e457f66Aa1`](https://explorer.mainnet.citrea.xyz/address/0xB511028582FDEe8AC66b524630Cc85e457f66Aa1) |
-| **Testnet** | [`0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE`](https://explorer.testnet.citrea.xyz/address/0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE) |
+| **Mainnet** | [`0xB511028582FDEe8AC66b524630Cc85e457f66Aa1`](https://citreascan.com/address/0xB511028582FDEe8AC66b524630Cc85e457f66Aa1) |
+| **Testnet** | [`0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE`](https://testnet.citreascan.com/address/0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE) |
 
 ---
 
@@ -310,8 +310,8 @@ Batch multiple contract calls in a single transaction.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c`](https://explorer.mainnet.citrea.xyz/address/0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c) |
-| **Testnet** | [`0xC1bD4864F267f8B032224817d33A7b53eD866F5e`](https://explorer.testnet.citrea.xyz/address/0xC1bD4864F267f8B032224817d33A7b53eD866F5e) |
+| **Mainnet** | [`0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c`](https://citreascan.com/address/0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c) |
+| **Testnet** | [`0xC1bD4864F267f8B032224817d33A7b53eD866F5e`](https://testnet.citreascan.com/address/0xC1bD4864F267f8B032224817d33A7b53eD866F5e) |
 
 ---
 
@@ -321,8 +321,8 @@ Admin contract for upgradeable proxies (e.g., NFT position descriptor).
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031`](https://explorer.mainnet.citrea.xyz/address/0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031) |
-| **Testnet** | [`0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4`](https://explorer.testnet.citrea.xyz/address/0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4) |
+| **Mainnet** | [`0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031`](https://citreascan.com/address/0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031) |
+| **Testnet** | [`0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4`](https://testnet.citreascan.com/address/0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4) |
 
 ---
 
@@ -345,8 +345,8 @@ Creates and manages V2 liquidity pools.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x400B27260bc8BbBF740e25B29a24EDf175d9fE56`](https://explorer.mainnet.citrea.xyz/address/0x400B27260bc8BbBF740e25B29a24EDf175d9fE56) |
-| **Testnet** | [`0xfc271758732F5eD3ddF19727B7E29BFC3325370d`](https://explorer.testnet.citrea.xyz/address/0xfc271758732F5eD3ddF19727B7E29BFC3325370d) |
+| **Mainnet** | [`0x400B27260bc8BbBF740e25B29a24EDf175d9fE56`](https://citreascan.com/address/0x400B27260bc8BbBF740e25B29a24EDf175d9fE56) |
+| **Testnet** | [`0xfc271758732F5eD3ddF19727B7E29BFC3325370d`](https://testnet.citreascan.com/address/0xfc271758732F5eD3ddF19727B7E29BFC3325370d) |
 
 ---
 
@@ -365,8 +365,8 @@ Routes swaps and liquidity operations for V2 pools.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x6BDea31C89E0A202cE84b5752BB2e827B39984ae`](https://explorer.mainnet.citrea.xyz/address/0x6BDea31C89E0A202cE84b5752BB2e827B39984ae) |
-| **Testnet** | [`0x37164703eF51EcB49C9a565C233a277003aE483f`](https://explorer.testnet.citrea.xyz/address/0x37164703eF51EcB49C9a565C233a277003aE483f) |
+| **Mainnet** | [`0x6BDea31C89E0A202cE84b5752BB2e827B39984ae`](https://citreascan.com/address/0x6BDea31C89E0A202cE84b5752BB2e827B39984ae) |
+| **Testnet** | [`0x37164703eF51EcB49C9a565C233a277003aE483f`](https://testnet.citreascan.com/address/0x37164703eF51EcB49C9a565C233a277003aE483f) |
 
 ---
 
@@ -380,8 +380,8 @@ Library for generating SVG artwork.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6`](https://explorer.mainnet.citrea.xyz/address/0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6) |
-| **Testnet** | [`0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef`](https://explorer.testnet.citrea.xyz/address/0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef) |
+| **Mainnet** | [`0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6`](https://citreascan.com/address/0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6) |
+| **Testnet** | [`0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef`](https://testnet.citreascan.com/address/0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef) |
 
 ### NonfungibleTokenPositionDescriptor
 
@@ -389,8 +389,8 @@ Generates token URI metadata for position NFTs.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x321c3C687D65C22A25f1e461e2568156adfD5D9C`](https://explorer.mainnet.citrea.xyz/address/0x321c3C687D65C22A25f1e461e2568156adfD5D9C) |
-| **Testnet** | [`0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD`](https://explorer.testnet.citrea.xyz/address/0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD) |
+| **Mainnet** | [`0x321c3C687D65C22A25f1e461e2568156adfD5D9C`](https://citreascan.com/address/0x321c3C687D65C22A25f1e461e2568156adfD5D9C) |
+| **Testnet** | [`0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD`](https://testnet.citreascan.com/address/0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD) |
 
 ### DescriptorProxy
 
@@ -398,8 +398,8 @@ Upgradeable proxy for the position descriptor.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x2e6D1f833a7951d02A47f244bA5F429699B87E4f`](https://explorer.mainnet.citrea.xyz/address/0x2e6D1f833a7951d02A47f244bA5F429699B87E4f) |
-| **Testnet** | [`0x6b8e06186725e41EC05045A957bA78A336b3dd70`](https://explorer.testnet.citrea.xyz/address/0x6b8e06186725e41EC05045A957bA78A336b3dd70) |
+| **Mainnet** | [`0x2e6D1f833a7951d02A47f244bA5F429699B87E4f`](https://citreascan.com/address/0x2e6D1f833a7951d02A47f244bA5F429699B87E4f) |
+| **Testnet** | [`0x6b8e06186725e41EC05045A957bA78A336b3dd70`](https://testnet.citreascan.com/address/0x6b8e06186725e41EC05045A957bA78A336b3dd70) |
 
 ---
 
@@ -433,8 +433,8 @@ Creates new tokens with bonding curve pricing that graduate to V2 pools.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0xF5E06d37091a252A3Ae6BFd575D97635625028b9`](https://explorer.mainnet.citrea.xyz/address/0xF5E06d37091a252A3Ae6BFd575D97635625028b9) |
-| **Testnet** | [`0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4`](https://explorer.testnet.citrea.xyz/address/0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4) |
+| **Mainnet** | [`0xF5E06d37091a252A3Ae6BFd575D97635625028b9`](https://citreascan.com/address/0xF5E06d37091a252A3Ae6BFd575D97635625028b9) |
+| **Testnet** | [`0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4`](https://testnet.citreascan.com/address/0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4) |
 
 ---
 
@@ -444,8 +444,8 @@ Template contract for bonding curve tokens.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c`](https://explorer.mainnet.citrea.xyz/address/0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c) |
-| **Testnet** | [`0xC46706007351AD7853159170fCC0489CCD04643D`](https://explorer.testnet.citrea.xyz/address/0xC46706007351AD7853159170fCC0489CCD04643D) |
+| **Mainnet** | [`0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c`](https://citreascan.com/address/0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c) |
+| **Testnet** | [`0xC46706007351AD7853159170fCC0489CCD04643D`](https://testnet.citreascan.com/address/0xC46706007351AD7853159170fCC0489CCD04643D) |
 
 ---
 
@@ -457,16 +457,16 @@ JuiceSwap integrates with LayerZero for cross-chain token bridging from Ethereum
 
 | Token | Address | Description |
 |-------|---------|-------------|
-| **USDC (L0)** | [`0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839`](https://explorer.mainnet.citrea.xyz/address/0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839) | LayerZero bridged USDC |
-| **USDT (L0)** | [`0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4`](https://explorer.mainnet.citrea.xyz/address/0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4) | LayerZero bridged USDT |
-| **WBTC.e** | [`0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d`](https://explorer.mainnet.citrea.xyz/address/0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d) | LayerZero bridged WBTC (OFT) |
+| **USDC (L0)** | [`0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839`](https://citreascan.com/address/0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839) | LayerZero bridged USDC |
+| **USDT (L0)** | [`0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4`](https://citreascan.com/address/0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4) | LayerZero bridged USDT |
+| **WBTC.e** | [`0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d`](https://citreascan.com/address/0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d) | LayerZero bridged WBTC (OFT) |
 
 ### OFT Adapters
 
 | Contract | Address | Description |
 |----------|---------|-------------|
-| **USDC OFT Adapter** | [`0x41710804caB0974638E1504DB723D7bddec22e30`](https://explorer.mainnet.citrea.xyz/address/0x41710804caB0974638E1504DB723D7bddec22e30) | Bridge adapter for USDC |
-| **USDT OFT Adapter** | [`0xF8b5983BFa11dc763184c96065D508AE1502C030`](https://explorer.mainnet.citrea.xyz/address/0xF8b5983BFa11dc763184c96065D508AE1502C030) | Bridge adapter for USDT |
+| **USDC OFT Adapter** | [`0x41710804caB0974638E1504DB723D7bddec22e30`](https://citreascan.com/address/0x41710804caB0974638E1504DB723D7bddec22e30) | Bridge adapter for USDC |
+| **USDT OFT Adapter** | [`0xF8b5983BFa11dc763184c96065D508AE1502C030`](https://citreascan.com/address/0xF8b5983BFa11dc763184c96065D508AE1502C030) | Bridge adapter for USDT |
 
 ---
 
@@ -484,8 +484,8 @@ The stablecoin used for trading pairs.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C`](https://explorer.mainnet.citrea.xyz/address/0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C) |
-| **Testnet** | [`0x6a850a548fdd050e8961223ec8FfCDfacEa57E39`](https://explorer.testnet.citrea.xyz/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) |
+| **Mainnet** | [`0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C`](https://citreascan.com/address/0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C) |
+| **Testnet** | [`0x6a850a548fdd050e8961223ec8FfCDfacEa57E39`](https://testnet.citreascan.com/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) |
 
 ### svJUSD (SavingsVaultJUSD)
 
@@ -497,8 +497,8 @@ Interest-bearing JUSD vault (ERC-4626). Used in pools instead of plain JUSD.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d`](https://explorer.mainnet.citrea.xyz/address/0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d) |
-| **Testnet** | [`0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B`](https://explorer.testnet.citrea.xyz/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) |
+| **Mainnet** | [`0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d`](https://citreascan.com/address/0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d) |
+| **Testnet** | [`0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B`](https://testnet.citreascan.com/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) |
 
 ### JUICE (Equity)
 
@@ -510,8 +510,8 @@ Governance token for voting and fee distribution.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4`](https://explorer.mainnet.citrea.xyz/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) |
-| **Testnet** | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
+| **Mainnet** | [`0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4`](https://citreascan.com/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) |
+| **Testnet** | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://testnet.citreascan.com/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) |
 
 ### WcBTC (Wrapped cBTC)
 
@@ -523,8 +523,8 @@ Wrapped version of native cBTC for ERC-20 compatibility.
 
 | Network | Address |
 |---------|---------|
-| **Mainnet** | [`0x3100000000000000000000000000000000000006`](https://explorer.mainnet.citrea.xyz/address/0x3100000000000000000000000000000000000006) |
-| **Testnet** | [`0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93`](https://explorer.testnet.citrea.xyz/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) |
+| **Mainnet** | [`0x3100000000000000000000000000000000000006`](https://citreascan.com/address/0x3100000000000000000000000000000000000006) |
+| **Testnet** | [`0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93`](https://testnet.citreascan.com/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) |
 
 ---
 
@@ -536,64 +536,64 @@ Wrapped version of native cBTC for ERC-20 compatibility.
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) | User-facing swap/LP interface |
-| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://explorer.mainnet.citrea.xyz/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) | Governance proposals |
-| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://explorer.mainnet.citrea.xyz/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) | Fee collection & distribution |
+| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://citreascan.com/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) | User-facing swap/LP interface |
+| JuiceSwapGovernor | [`0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae`](https://citreascan.com/address/0x51f3D5905C768CCA2D4904Ca7877614CeaD607ae) | Governance proposals |
+| JuiceSwapFeeCollector | [`0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b`](https://citreascan.com/address/0xD2D68A452A6f5d9090153f52E64f23cc7fF8A97b) | Fee collection & distribution |
 
 #### Uniswap V3
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) | V3 pool creation |
-| SwapRouter | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://explorer.mainnet.citrea.xyz/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) | V3 swap routing |
-| NonfungiblePositionManager | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://explorer.mainnet.citrea.xyz/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) | LP NFT management |
-| QuoterV2 | [`0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425`](https://explorer.mainnet.citrea.xyz/address/0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425) | Price quotes |
-| TickLens | [`0xD9d430f27F922A3316d22Cd9d58558f45Dad8012`](https://explorer.mainnet.citrea.xyz/address/0xD9d430f27F922A3316d22Cd9d58558f45Dad8012) | Tick data fetching |
-| V3Migrator | [`0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6`](https://explorer.mainnet.citrea.xyz/address/0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6) | V2→V3 migration |
-| V3Staker | [`0xB511028582FDEe8AC66b524630Cc85e457f66Aa1`](https://explorer.mainnet.citrea.xyz/address/0xB511028582FDEe8AC66b524630Cc85e457f66Aa1) | Liquidity mining |
+| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://citreascan.com/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) | V3 pool creation |
+| SwapRouter | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://citreascan.com/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) | V3 swap routing |
+| NonfungiblePositionManager | [`0x3D3821D358f56395d4053954f98aec0E1F0fa568`](https://citreascan.com/address/0x3D3821D358f56395d4053954f98aec0E1F0fa568) | LP NFT management |
+| QuoterV2 | [`0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425`](https://citreascan.com/address/0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425) | Price quotes |
+| TickLens | [`0xD9d430f27F922A3316d22Cd9d58558f45Dad8012`](https://citreascan.com/address/0xD9d430f27F922A3316d22Cd9d58558f45Dad8012) | Tick data fetching |
+| V3Migrator | [`0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6`](https://citreascan.com/address/0xB9e69B428a5BfF4aCA9bfE66E80BAfD0477165E6) | V2→V3 migration |
+| V3Staker | [`0xB511028582FDEe8AC66b524630Cc85e457f66Aa1`](https://citreascan.com/address/0xB511028582FDEe8AC66b524630Cc85e457f66Aa1) | Liquidity mining |
 
 #### Uniswap V2
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| UniswapV2Factory | [`0x400B27260bc8BbBF740e25B29a24EDf175d9fE56`](https://explorer.mainnet.citrea.xyz/address/0x400B27260bc8BbBF740e25B29a24EDf175d9fE56) | V2 pair creation |
-| UniswapV2Router02 | [`0x6BDea31C89E0A202cE84b5752BB2e827B39984ae`](https://explorer.mainnet.citrea.xyz/address/0x6BDea31C89E0A202cE84b5752BB2e827B39984ae) | V2 swap routing |
+| UniswapV2Factory | [`0x400B27260bc8BbBF740e25B29a24EDf175d9fE56`](https://citreascan.com/address/0x400B27260bc8BbBF740e25B29a24EDf175d9fE56) | V2 pair creation |
+| UniswapV2Router02 | [`0x6BDea31C89E0A202cE84b5752BB2e827B39984ae`](https://citreascan.com/address/0x6BDea31C89E0A202cE84b5752BB2e827B39984ae) | V2 swap routing |
 
 #### Infrastructure
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| Multicall2 | [`0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c`](https://explorer.mainnet.citrea.xyz/address/0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c) | Batch calls |
-| ProxyAdmin | [`0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031`](https://explorer.mainnet.citrea.xyz/address/0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031) | Proxy administration |
-| NFTDescriptorLibrary | [`0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6`](https://explorer.mainnet.citrea.xyz/address/0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6) | NFT SVG generation |
-| PositionDescriptor | [`0x321c3C687D65C22A25f1e461e2568156adfD5D9C`](https://explorer.mainnet.citrea.xyz/address/0x321c3C687D65C22A25f1e461e2568156adfD5D9C) | NFT metadata |
-| DescriptorProxy | [`0x2e6D1f833a7951d02A47f244bA5F429699B87E4f`](https://explorer.mainnet.citrea.xyz/address/0x2e6D1f833a7951d02A47f244bA5F429699B87E4f) | Upgradeable descriptor |
+| Multicall2 | [`0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c`](https://citreascan.com/address/0xd277541Ab4f406Ac9530C41aB3d1818C276e1A1c) | Batch calls |
+| ProxyAdmin | [`0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031`](https://citreascan.com/address/0x7864b1f116F939eeCFDCf76B532d5BBDa5F80031) | Proxy administration |
+| NFTDescriptorLibrary | [`0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6`](https://citreascan.com/address/0x106ff466B27D10e9Ab932c443Cd790BbA0027ec6) | NFT SVG generation |
+| PositionDescriptor | [`0x321c3C687D65C22A25f1e461e2568156adfD5D9C`](https://citreascan.com/address/0x321c3C687D65C22A25f1e461e2568156adfD5D9C) | NFT metadata |
+| DescriptorProxy | [`0x2e6D1f833a7951d02A47f244bA5F429699B87E4f`](https://citreascan.com/address/0x2e6D1f833a7951d02A47f244bA5F429699B87E4f) | Upgradeable descriptor |
 
 #### Launchpad
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| TokenFactory | [`0xF5E06d37091a252A3Ae6BFd575D97635625028b9`](https://explorer.mainnet.citrea.xyz/address/0xF5E06d37091a252A3Ae6BFd575D97635625028b9) | Bonding curve tokens |
-| BondingCurveToken | [`0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c`](https://explorer.mainnet.citrea.xyz/address/0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c) | Token implementation |
+| TokenFactory | [`0xF5E06d37091a252A3Ae6BFd575D97635625028b9`](https://citreascan.com/address/0xF5E06d37091a252A3Ae6BFd575D97635625028b9) | Bonding curve tokens |
+| BondingCurveToken | [`0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c`](https://citreascan.com/address/0xB8418EDc48c0a63a0Ab29F50BdE09552A8aECa0c) | Token implementation |
 
 #### Tokens
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| JUSD | [`0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C`](https://explorer.mainnet.citrea.xyz/address/0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C) | Stablecoin |
-| svJUSD | [`0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d`](https://explorer.mainnet.citrea.xyz/address/0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d) | Savings vault |
-| JUICE | [`0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4`](https://explorer.mainnet.citrea.xyz/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) | Governance token |
-| WcBTC | [`0x3100000000000000000000000000000000000006`](https://explorer.mainnet.citrea.xyz/address/0x3100000000000000000000000000000000000006) | Wrapped cBTC |
+| JUSD | [`0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C`](https://citreascan.com/address/0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C) | Stablecoin |
+| svJUSD | [`0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d`](https://citreascan.com/address/0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d) | Savings vault |
+| JUICE | [`0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4`](https://citreascan.com/address/0x2A36f2b204B46Fd82653cd06d00c7fF757C99ae4) | Governance token |
+| WcBTC | [`0x3100000000000000000000000000000000000006`](https://citreascan.com/address/0x3100000000000000000000000000000000000006) | Wrapped cBTC |
 
 #### LayerZero Bridge
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| USDC (L0) | [`0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839`](https://explorer.mainnet.citrea.xyz/address/0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839) | Bridged USDC |
-| USDC OFT Adapter | [`0x41710804caB0974638E1504DB723D7bddec22e30`](https://explorer.mainnet.citrea.xyz/address/0x41710804caB0974638E1504DB723D7bddec22e30) | USDC bridge adapter |
-| USDT (L0) | [`0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4`](https://explorer.mainnet.citrea.xyz/address/0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4) | Bridged USDT |
-| USDT OFT Adapter | [`0xF8b5983BFa11dc763184c96065D508AE1502C030`](https://explorer.mainnet.citrea.xyz/address/0xF8b5983BFa11dc763184c96065D508AE1502C030) | USDT bridge adapter |
-| WBTC.e | [`0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d`](https://explorer.mainnet.citrea.xyz/address/0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d) | Bridged WBTC |
+| USDC (L0) | [`0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839`](https://citreascan.com/address/0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839) | Bridged USDC |
+| USDC OFT Adapter | [`0x41710804caB0974638E1504DB723D7bddec22e30`](https://citreascan.com/address/0x41710804caB0974638E1504DB723D7bddec22e30) | USDC bridge adapter |
+| USDT (L0) | [`0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4`](https://citreascan.com/address/0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4) | Bridged USDT |
+| USDT OFT Adapter | [`0xF8b5983BFa11dc763184c96065D508AE1502C030`](https://citreascan.com/address/0xF8b5983BFa11dc763184c96065D508AE1502C030) | USDT bridge adapter |
+| WBTC.e | [`0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d`](https://citreascan.com/address/0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d) | Bridged WBTC |
 
 ### Testnet (Chain ID: 5115)
 
@@ -601,54 +601,54 @@ Wrapped version of native cBTC for ERC-20 compatibility.
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) | User-facing swap/LP interface |
-| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://explorer.testnet.citrea.xyz/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) | Governance proposals |
-| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://explorer.testnet.citrea.xyz/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) | Fee collection & distribution |
+| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://testnet.citreascan.com/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) | User-facing swap/LP interface |
+| JuiceSwapGovernor | [`0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8`](https://testnet.citreascan.com/address/0x8AFD7CB73Ce85b44996B86ec604c125af244A2B8) | Governance proposals |
+| JuiceSwapFeeCollector | [`0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E`](https://testnet.citreascan.com/address/0xfac6303F78A2b316a20eD927Ba0f7a7d07AaC47E) | Fee collection & distribution |
 
 #### Uniswap V3
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) | V3 pool creation |
-| SwapRouter | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) | V3 swap routing |
-| NonfungiblePositionManager | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://explorer.testnet.citrea.xyz/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) | LP NFT management |
-| QuoterV2 | [`0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d`](https://explorer.testnet.citrea.xyz/address/0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d) | Price quotes |
-| TickLens | [`0xa0Fe847227eE5076bC5D1D3c605261837fa047fB`](https://explorer.testnet.citrea.xyz/address/0xa0Fe847227eE5076bC5D1D3c605261837fa047fB) | Tick data fetching |
-| V3Migrator | [`0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8`](https://explorer.testnet.citrea.xyz/address/0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8) | V2→V3 migration |
-| V3Staker | [`0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE`](https://explorer.testnet.citrea.xyz/address/0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE) | Liquidity mining |
+| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://testnet.citreascan.com/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) | V3 pool creation |
+| SwapRouter | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://testnet.citreascan.com/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) | V3 swap routing |
+| NonfungiblePositionManager | [`0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1`](https://testnet.citreascan.com/address/0x86e7A161cb9696E6d438c0c77dd18244efa2B8b1) | LP NFT management |
+| QuoterV2 | [`0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d`](https://testnet.citreascan.com/address/0x719a4C7B49E5361a39Dc83c23b353CA220D9B99d) | Price quotes |
+| TickLens | [`0xa0Fe847227eE5076bC5D1D3c605261837fa047fB`](https://testnet.citreascan.com/address/0xa0Fe847227eE5076bC5D1D3c605261837fa047fB) | Tick data fetching |
+| V3Migrator | [`0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8`](https://testnet.citreascan.com/address/0xfa83918a27F9cC32619ae1A85f7e1Ae3e3F6Ceb8) | V2→V3 migration |
+| V3Staker | [`0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE`](https://testnet.citreascan.com/address/0xeeb6c9514f1E11E48f18DD8822eF3Db1B179DcCE) | Liquidity mining |
 
 #### Uniswap V2
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| UniswapV2Factory | [`0xfc271758732F5eD3ddF19727B7E29BFC3325370d`](https://explorer.testnet.citrea.xyz/address/0xfc271758732F5eD3ddF19727B7E29BFC3325370d) | V2 pair creation |
-| UniswapV2Router02 | [`0x37164703eF51EcB49C9a565C233a277003aE483f`](https://explorer.testnet.citrea.xyz/address/0x37164703eF51EcB49C9a565C233a277003aE483f) | V2 swap routing |
+| UniswapV2Factory | [`0xfc271758732F5eD3ddF19727B7E29BFC3325370d`](https://testnet.citreascan.com/address/0xfc271758732F5eD3ddF19727B7E29BFC3325370d) | V2 pair creation |
+| UniswapV2Router02 | [`0x37164703eF51EcB49C9a565C233a277003aE483f`](https://testnet.citreascan.com/address/0x37164703eF51EcB49C9a565C233a277003aE483f) | V2 swap routing |
 
 #### Infrastructure
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| Multicall2 | [`0xC1bD4864F267f8B032224817d33A7b53eD866F5e`](https://explorer.testnet.citrea.xyz/address/0xC1bD4864F267f8B032224817d33A7b53eD866F5e) | Batch calls |
-| ProxyAdmin | [`0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4`](https://explorer.testnet.citrea.xyz/address/0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4) | Proxy administration |
-| NFTDescriptorLibrary | [`0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef`](https://explorer.testnet.citrea.xyz/address/0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef) | NFT SVG generation |
-| PositionDescriptor | [`0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD`](https://explorer.testnet.citrea.xyz/address/0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD) | NFT metadata |
-| DescriptorProxy | [`0x6b8e06186725e41EC05045A957bA78A336b3dd70`](https://explorer.testnet.citrea.xyz/address/0x6b8e06186725e41EC05045A957bA78A336b3dd70) | Upgradeable descriptor |
+| Multicall2 | [`0xC1bD4864F267f8B032224817d33A7b53eD866F5e`](https://testnet.citreascan.com/address/0xC1bD4864F267f8B032224817d33A7b53eD866F5e) | Batch calls |
+| ProxyAdmin | [`0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4`](https://testnet.citreascan.com/address/0xCdc7C81784F9D3b4061e754477BEA077B7B4cCa4) | Proxy administration |
+| NFTDescriptorLibrary | [`0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef`](https://testnet.citreascan.com/address/0x73e3bDE5af755C34fC4487cA083cb8035a43d1Ef) | NFT SVG generation |
+| PositionDescriptor | [`0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD`](https://testnet.citreascan.com/address/0x17a12a5461Bf35d4383B3f039d7e5Cd7d92aAACD) | NFT metadata |
+| DescriptorProxy | [`0x6b8e06186725e41EC05045A957bA78A336b3dd70`](https://testnet.citreascan.com/address/0x6b8e06186725e41EC05045A957bA78A336b3dd70) | Upgradeable descriptor |
 
 #### Launchpad
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| TokenFactory | [`0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4`](https://explorer.testnet.citrea.xyz/address/0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4) | Bonding curve tokens |
-| BondingCurveToken | [`0xC46706007351AD7853159170fCC0489CCD04643D`](https://explorer.testnet.citrea.xyz/address/0xC46706007351AD7853159170fCC0489CCD04643D) | Token implementation |
+| TokenFactory | [`0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4`](https://testnet.citreascan.com/address/0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4) | Bonding curve tokens |
+| BondingCurveToken | [`0xC46706007351AD7853159170fCC0489CCD04643D`](https://testnet.citreascan.com/address/0xC46706007351AD7853159170fCC0489CCD04643D) | Token implementation |
 
 #### Tokens
 
 | Contract | Address | Purpose |
 |----------|---------|---------|
-| JUSD | [`0x6a850a548fdd050e8961223ec8FfCDfacEa57E39`](https://explorer.testnet.citrea.xyz/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) | Stablecoin |
-| svJUSD | [`0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B`](https://explorer.testnet.citrea.xyz/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) | Savings vault |
-| JUICE | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://explorer.testnet.citrea.xyz/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) | Governance token |
-| WcBTC | [`0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93`](https://explorer.testnet.citrea.xyz/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) | Wrapped cBTC |
+| JUSD | [`0x6a850a548fdd050e8961223ec8FfCDfacEa57E39`](https://testnet.citreascan.com/address/0x6a850a548fdd050e8961223ec8FfCDfacEa57E39) | Stablecoin |
+| svJUSD | [`0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B`](https://testnet.citreascan.com/address/0x802a29bD29f02c8C477Af5362f9ba88FAe39Cc7B) | Savings vault |
+| JUICE | [`0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E`](https://testnet.citreascan.com/address/0x7fa131991c8A7d8C21b11391C977Fc7c4c8e0D5E) | Governance token |
+| WcBTC | [`0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93`](https://testnet.citreascan.com/address/0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93) | Wrapped cBTC |
 
 ---
 
@@ -680,5 +680,5 @@ All source code is available on GitHub:
 
 | Network | Chain ID | Explorer |
 |---------|----------|----------|
-| **Mainnet** | 4114 | [explorer.mainnet.citrea.xyz](https://explorer.mainnet.citrea.xyz) |
-| **Testnet** | 5115 | [explorer.testnet.citrea.xyz](https://explorer.testnet.citrea.xyz) |
+| **Mainnet** | 4114 | [explorer.mainnet.citrea.xyz](https://citreascan.com) |
+| **Testnet** | 5115 | [explorer.testnet.citrea.xyz](https://testnet.citreascan.com) |

--- a/src/swap.md
+++ b/src/swap.md
@@ -191,14 +191,14 @@ event SwapExecuted(
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://explorer.mainnet.citrea.xyz/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
-| SwapRouter | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://explorer.mainnet.citrea.xyz/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) |
-| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://explorer.mainnet.citrea.xyz/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
+| JuiceSwapGateway | [`0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9`](https://citreascan.com/address/0xAFcfD58Fe17BEb0c9D15C51D19519682dFcdaab9) |
+| SwapRouter | [`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`](https://citreascan.com/address/0x565eD3D57fe40f78A46f348C220121AE093c3cF8) |
+| UniswapV3Factory | [`0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82`](https://citreascan.com/address/0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82) |
 
 ### Testnet (Chain ID: 5115)
 
 | Contract | Address |
 |----------|---------|
-| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://explorer.testnet.citrea.xyz/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
-| SwapRouter | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://explorer.testnet.citrea.xyz/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
-| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://explorer.testnet.citrea.xyz/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |
+| JuiceSwapGateway | [`0x8eE3Dd585752805A258ad3a963949a7c3fec44eB`](https://testnet.citreascan.com/address/0x8eE3Dd585752805A258ad3a963949a7c3fec44eB) |
+| SwapRouter | [`0x26C106BC45E0dd599cbDD871605497B2Fc87c185`](https://testnet.citreascan.com/address/0x26C106BC45E0dd599cbDD871605497B2Fc87c185) |
+| UniswapV3Factory | [`0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238`](https://testnet.citreascan.com/address/0xdd6Db52dB41CE2C03002bB1adFdCC8E91C594238) |


### PR DESCRIPTION
## Summary
- Update RPC URLs from citrea.xyz to citreascan.com
- Update explorer URLs to new citreascan.com domain

## Changes
| Old URL | New URL |
|---------|---------|
| `https://rpc.citrea.xyz` | `https://rpc.citreascan.com` |
| `https://rpc.testnet.citrea.xyz` | `https://rpc.testnet.citreascan.com` |
| `https://explorer.mainnet.citrea.xyz` | `https://citreascan.com` |
| `https://explorer.testnet.citrea.xyz` | `https://testnet.citreascan.com` |

## Test plan
- [ ] Verify all documentation links work correctly