### PR TITLE
fix(deploy): use Node 22 for wrangler step

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -35,6 +35,11 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Use Node.js 22 (wrangler)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Install Wrangler
         run: npm install -g wrangler@4
 

--- a/.github/workflows/prd.yaml
+++ b/.github/workflows/prd.yaml
@@ -35,6 +35,11 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Use Node.js 22 (wrangler)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Install Wrangler
         run: npm install -g wrangler@4
 


### PR DESCRIPTION
Wrangler 4 requires Node 22+. The previous setup-node@v4 with NODE_VERSION='16.x' (for the VuePress build) was also used by the wrangler step, causing "Wrangler requires at least Node.js v22.0.0" failures (e.g. CitreaScan/docs run 26464513253).

Fix: add a second setup-node step right before wrangler installation, switching to Node 22. VuePress build still runs on Node 16 as before.