### PR TITLE
feat: add robots.txt allowing search and AI crawlers

### DIFF
--- a/src/.vuepress/public/robots.txt
+++ b/src/.vuepress/public/robots.txt
@@ -1,0 +1,38 @@
+# robots.txt — JuiceSwap documentation (docs.juiceswap.com)
+#
+# Public documentation. We explicitly WANT both search engines and AI agents to
+# crawl, index, and learn from this content. This file is version-controlled in
+# this repository and is the authoritative crawl policy for this site.
+#
+# Content signals: all uses are granted — search, AI input / retrieval-augmented
+# generation, and AI training. We deliberately do NOT signal ai-train=no.
+
+User-agent: *
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+# Major AI crawlers are explicitly welcome. Some honor only their own named
+# record, so each is listed in addition to the wildcard group above.
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /


### PR DESCRIPTION
## Summary

Adds a repository-controlled \`robots.txt\` as the authoritative crawl policy for **docs.juiceswap.com**.

This is public documentation, and we explicitly **want** both search engines and AI agents to crawl, index, and learn from it. The file makes that policy explicit and version-controlled rather than relying on host defaults.

## What it does

- **Wildcard group** (\`User-agent: *\`): allows all paths and emits a \`Content-Signal\` granting all uses — \`search=yes, ai-input=yes, ai-train=yes\`. We deliberately do **not** signal \`ai-train=no\`.
- **Named AI crawlers** explicitly welcomed (ClaudeBot, GPTBot, Google-Extended, CCBot, Bytespider, Amazonbot, Applebot-Extended, meta-externalagent), since some honor only their own named record in addition to the wildcard group.

## Placement / build

This is a VuePress 1.x site (\`vuepress build src\`, output \`src/.vuepress/dist\`, published to Cloudflare Pages). The file is placed in the VuePress **public** directory:

\`\`\`
src/.vuepress/public/robots.txt
\`\`\`

VuePress copies \`public/\` contents verbatim to the published site root, so it is served at \`/robots.txt\`. Verified locally with a full build — the file appears unchanged at \`dist/robots.txt\`.

## Sitemap

No \`Sitemap:\` line is included: the site does not build a sitemap (no sitemap plugin configured) and \`https://docs.juiceswap.com/sitemap.xml\` currently returns 404. The line can be added later if a sitemap is introduced.

> Note: the published site is served via Cloudflare; this repo-controlled file is the source of truth for crawl policy at build/deploy time.